### PR TITLE
fix: include *.hbs templates as assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
       "dist/**/*.js"
     ],
     "assets": [
-      "src/**/templates/*.hbs"
+      "src/lib/**/**/*.hbs",
+      "src/lib/**/**/*.html"
     ]
   }
 }

--- a/src/lib/generate-report/index.ts
+++ b/src/lib/generate-report/index.ts
@@ -30,7 +30,7 @@ export async function generateHtmlReport(
       hbsTemplate === DEFAULT_TEMPLATE ? 'default template' : hbsTemplate
     }`,
   );
-  debug(`✅ Registered Handlebars.js partials`);
+  debug(`ℹ️ Compiling Handlebars.js template ${hbsTemplate}`);
   const htmlTemplate = await compileTemplate(hbsTemplate);
   debug(`✅ Compiled template ${hbsTemplate}`);
   const transformedData = transformDataFunc[view](orgPublicId, data, orgData);


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Make sure *.hbs templates are included in the end binary with `pkg .`