### PR TITLE
feat: pkg was not copying assets, swapping to nexe fixes that

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
                 color: '#42e2f4'
                 message: Starting snyk-licenses test
             - checkout
-            - run: npm install semantic-release @semantic-release/exec pkg --save-dev
+            - run: npm install semantic-release @semantic-release/exec nexe --save-dev
             - run: npm install
             - run:
                 name: Install Headless Chrome dependencies

--- a/.releaserc
+++ b/.releaserc
@@ -9,7 +9,7 @@
     {
       "//": "build the alpine, macos, linux and windows binaries",
       "path": "@semantic-release/exec",
-      "cmd": "npx pkg . -t node12-linux-x64,node12-macos-x64,node12-win-x64"
+      "cmd": "npx nexe . -t node12-linux-x64,node12-macos-x64,node12-win-x64"
     },
     {
       "//": "shasum all binaries",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "build-watch": "tsc -w && npm run copy:templates",
     "prepare": "npm run build",
     "snyk-test": "snyk test",
-    "pkg-binaries": "npx pkg . -t node12-linux-x64,node12-macos-x64,node12-win-x64 --out-path ./dist/binaries",
     "copy:templates": "cpx 'src/**/*.hbs' ./dist"
   },
   "bin": {


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Move to nexe instead of `pkg` because `pkg` is not copying the assets ([issue raised](https://github.com/vercel/pkg/issues/893))