### PR TITLE
fix: drop including chromuim from binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,10 +75,7 @@
     ],
     "assets": [
       "dist/lib/**/**/*.hbs",
-      "dist/lib/**/**/*.html",
-      "dist/build/*",
-      "dist/STANDALONE",
-      "node_modules/puppeteer/.local-chromium"
+      "dist/lib/**/**/*.html"
     ]
   }
 }


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Since it is not used at the moment drop to reduce binary size