### PR TITLE
chore: only post to slack on failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
                 token-variable: SNYK_TOKEN_PROD
             - run: npx semantic-release
             - slack/status:
-                fail_only: false
+                fail_only: true
                 only_for_branches: master
     build-test:
         docker:
@@ -68,7 +68,7 @@ jobs:
                 monitor-on-build: false
                 token-variable: SNYK_TOKEN_PROD
             - slack/status:
-                fail_only: false
+                fail_only: true
                 only_for_branches: master
     build-test-from-fork:
         docker:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 ## Contributor Agreement
-A pull-request will only be considered for merging into the upstream codebase after you have signed our [contributor agreement](https://github.com/snyk/snyk/blob/master/Contributor-Agreement.md), assigning us the rights to the contributed code and granting you a license to use it in return. If you submit a pull request, you will be prompted to review and sign the agreement with one click (we use [CLA assistant](https://cla-assistant.io/)).
+A pull-request will only be considered for merging into the upstream codebase after you have signed our [contributor agreement](../Contributor-Agreement.md), assigning us the rights to the contributed code and granting you a license to use it in return. If you submit a pull request, you will be prompted to review and sign the agreement with one click (we use [CLA assistant](https://cla-assistant.io/)).
 
 ## Commit messages
 


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Stop sending messages to slack on success from Circle + fix agreement link