### PR TITLE
feat: allow filter by projects

### DIFF
--- a/src/cmds/json.ts
+++ b/src/cmds/json.ts
@@ -3,6 +3,7 @@ import * as debugLib from 'debug';
 import { getApiToken } from '../lib/get-api-token';
 import { generateLicenseData } from '../lib/generate-org-license-report';
 import { SupportedViews } from '../lib/types';
+import * as _ from 'lodash';
 
 const debug = debugLib('snyk-licenses:json');
 
@@ -12,22 +13,33 @@ export const builder = {
   orgPublicId: {
     required: true,
     default: undefined,
-  }
+  },
+  project: {
+    default: [],
+    desc:
+      'Project ID to filter the results by. E.g. --project=uuid --project=uuid2',
+  },
 };
 export const aliases = ['j'];
 
 export async function handler(argv: {
   orgPublicId: string;
   view: SupportedViews;
+  project?: string | string[];
 }) {
   try {
-    const { orgPublicId, view } = argv;
-    debug('ℹ️  Options: ' + JSON.stringify({ orgPublicId, view }));
-    // check SNYK_TOKEN is set as the sdk uses it
+    const { orgPublicId, view, project } = argv;
+    debug(
+      'ℹ️  Options: ' +
+        JSON.stringify({ orgPublicId, view, project: _.castArray(project) }),
+    );
     getApiToken();
-    // TODO: define and pass options to help filter the response
-    // based on filters available in API
-    const data = await generateLicenseData(orgPublicId, {});
+    const options = {
+      filters: {
+        projects: _.castArray(project),
+      },
+    };
+    const data = await generateLicenseData(orgPublicId, options);
     console.log(JSON.stringify(data));
   } catch (e) {
     console.error(e);

--- a/src/lib/api/org/dependencies.ts
+++ b/src/lib/api/org/dependencies.ts
@@ -2,33 +2,23 @@ import 'source-map-support/register';
 import * as debugLib from 'debug';
 import * as snykApiSdk from 'snyk-api-ts-client';
 import { getApiToken } from '../../get-api-token';
-import { SortBy, Order } from './types';
+import { GetLicenseDataOptions } from '../../types';
 
 const debug = debugLib('snyk-licenses:getDependenciesDataForOrg');
 
-interface GetDependenciesDataOptions {
-  sortBy: SortBy;
-  order: Order;
-  filters?: snykApiSdk.OrgTypes.DependenciesPostBodyType;
-}
-
 export async function getDependenciesDataForOrg(
   orgPublicId: string,
-  options?: GetDependenciesDataOptions,
+  options?: GetLicenseDataOptions,
 ): Promise<snykApiSdk.OrgTypes.DependenciesPostResponseType> {
   getApiToken();
   const snykApiClient = await new snykApiSdk.Org({ orgId: orgPublicId });
-  const sortBy = options?.sortBy;
-  const order = options?.order;
   const body: snykApiSdk.OrgTypes.DependenciesPostBodyType = {
-    ...options?.filters,
+    filters: options?.filters,
   };
   try {
     const dependenciesData = await getAllDependenciesData(
       snykApiClient,
       body,
-      sortBy,
-      order,
     );
     return dependenciesData;
   } catch (e) {
@@ -40,15 +30,11 @@ export async function getDependenciesDataForOrg(
 async function getAllDependenciesData(
   snykApiClient,
   body,
-  sortBy,
-  order,
   page = 1,
 ): Promise<snykApiSdk.OrgTypes.DependenciesPostResponseType> {
   const perPage = 200;
   const dependenciesData = await snykApiClient.dependencies.post(
     body,
-    sortBy,
-    order,
     page,
     perPage,
   );
@@ -58,8 +44,6 @@ async function getAllDependenciesData(
     const data = await getAllDependenciesData(
       snykApiClient,
       body,
-      sortBy,
-      order,
       nextPage,
     );
     result.results = [...result.results, ...data.results];

--- a/src/lib/api/org/licenses.ts
+++ b/src/lib/api/org/licenses.ts
@@ -2,15 +2,9 @@ import 'source-map-support/register';
 import * as debugLib from 'debug';
 import * as snykApiSdk from 'snyk-api-ts-client';
 import { getApiToken } from '../../get-api-token';
-import { SortBy, Order } from './types';
+import { GetLicenseDataOptions } from '../../types';
 
 const debug = debugLib('snyk-licenses:getLicenseDataForOrg');
-
-interface GetLicenseDataOptions {
-  sortBy: SortBy;
-  order: Order;
-  filters?: snykApiSdk.OrgTypes.LicensesPostBodyType;
-}
 
 export async function getLicenseDataForOrg(
   orgPublicId: string,
@@ -18,13 +12,11 @@ export async function getLicenseDataForOrg(
 ): Promise<snykApiSdk.OrgTypes.LicensesPostResponseType> {
   getApiToken();
   const snykApiClient = await new snykApiSdk.Org({ orgId: orgPublicId });
-  const sortBy = options?.sortBy;
-  const order = options?.order;
   const body: snykApiSdk.OrgTypes.LicensesPostBodyType = {
-    ...options?.filters,
+    filters: options?.filters,
   };
   try {
-    const licenseData = await getAllLicensesData(snykApiClient, body, sortBy, order);
+    const licenseData = await getAllLicensesData(snykApiClient, body);
     return licenseData;
   } catch (e) {
     debug('❌ Failed to fetch licenses' + e);
@@ -35,15 +27,11 @@ export async function getLicenseDataForOrg(
 async function getAllLicensesData(
   snykApiClient,
   body,
-  sortBy,
-  order,
   page = 1,
 ): Promise<snykApiSdk.OrgTypes.LicensesPostResponseType> {
   const perPage = 200;
   const licensesData = await snykApiClient.licenses.post(
     body,
-    sortBy,
-    order,
     page,
     perPage,
   );
@@ -53,8 +41,6 @@ async function getAllLicensesData(
     const data = await getAllLicensesData(
       snykApiClient,
       body,
-      sortBy,
-      order,
       nextPage,
     );
     result.results.push(data.results);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,6 +5,7 @@ export interface Dependency {
   packageManager: string;
 }
 
+export type LicenseSeverity = 'none' | 'high' | 'medium' | 'low';
 export type EnrichedDependency = Dependency & DependencyData;
 
 export interface LicenseReportDataEntry {
@@ -24,7 +25,7 @@ export interface LicenseReportDataEntry {
   /**
    * Snyk license severity setup on the org license policy
    */
-  severity?: 'none' | 'high' | 'medium' | 'low';
+  severity?: LicenseSeverity;
   /**
    * Snyk license instruction setup on the org license policy
    */
@@ -129,8 +130,24 @@ export interface DependencyData {
 }
 [];
 
-
 export const enum SupportedViews {
   ORG_LICENSES = 'org-licenses',
   PROJECT_DEPENDENCIES = 'project-dependencies',
+}
+export interface GetLicenseDataOptions {
+  filters?: {
+    projects?: string[];
+    /**
+     * The list of dependency IDs to filter the results by
+     */
+    dependencies?: string[];
+    /**
+     * The list of license IDs to filter the results by
+     */
+    licenses?: string[];
+    /**
+     * The severities to filter the results by
+     */
+    severity?: LicenseSeverity[];
+  };
 }

--- a/test/lib/generate-license-report-data.test.ts
+++ b/test/lib/generate-license-report-data.test.ts
@@ -4,6 +4,7 @@ describe('Get org licenses', () => {
   const OLD_ENV = process.env;
   process.env.SNYK_TOKEN = process.env.SNYK_TEST_TOKEN;
   const ORG_ID = process.env.TEST_ORG_ID as string;
+  const PROJECT_ID = process.env.TEST_PROJECT_ID as string;
 
   afterAll(async () => {
     process.env = { ...OLD_ENV };
@@ -12,18 +13,59 @@ describe('Get org licenses', () => {
     expect(process.env.SNYK_TOKEN).not.toBeNull();
     expect(process.env.ORG_ID).not.toBeNull();
   });
+
   test('License data is generated as expected', async () => {
     const licenseRes = await generateLicenseData(ORG_ID, {});
     expect(Object.keys(licenseRes).length >= 11).toBeTruthy();
     expect(licenseRes['Unknown'].licenseUrl).toBeUndefined();
     expect(licenseRes['Unknown'].licenseText).toBeUndefined();
     expect(licenseRes['Unlicense'].licenseText).not.toBeNull();
-    expect(licenseRes['Unlicense'].licenseUrl).toBe('https://spdx.org/licenses/Unlicense.html');
-    expect(licenseRes['Unlicense'].licenseUrl).toBe('https://spdx.org/licenses/Unlicense.html');
+    expect(licenseRes['Unlicense'].licenseUrl).toBe(
+      'https://spdx.org/licenses/Unlicense.html',
+    );
+    expect(licenseRes['Unlicense'].licenseUrl).toBe(
+      'https://spdx.org/licenses/Unlicense.html',
+    );
     expect(licenseRes['Unlicense'].dependencies[0].copyright).not.toBeNull();
     expect(licenseRes['Unlicense'].dependencies[0].issuesMedium).not.toBeNull();
-    expect(licenseRes['Unlicense'].dependencies[0].latestVersion).not.toBeNull();
-  }, 50000);
+    expect(
+      licenseRes['Unlicense'].dependencies[0].latestVersion,
+    ).not.toBeNull();
+
+    expect(licenseRes['Zlib'].projects.length).toEqual(2);
+    expect(licenseRes['ISC'].projects.length).toEqual(3);
+    expect(licenseRes['ISC'].dependencies[0].copyright).toEqual(
+      ['Copyright (c) Isaac Z. Schlueter and Contributors'],
+    );
+  }, 70000);
+
+  test('License data is generated as expected', async () => {
+    const licenseRes = await generateLicenseData(ORG_ID, {
+      filters: {
+        projects: [PROJECT_ID],
+      },
+    });
+    expect(Object.keys(licenseRes).length >= 11).toBeTruthy();
+    expect(licenseRes['Unknown']).toBeUndefined();
+    expect(licenseRes['Unlicense'].licenseText).not.toBeNull();
+    expect(licenseRes['Unlicense'].licenseUrl).toBe(
+      'https://spdx.org/licenses/Unlicense.html',
+    );
+    expect(licenseRes['Unlicense'].licenseUrl).toBe(
+      'https://spdx.org/licenses/Unlicense.html',
+    );
+    expect(licenseRes['Unlicense'].dependencies[0].copyright).not.toBeNull();
+    expect(licenseRes['Unlicense'].dependencies[0].issuesMedium).not.toBeNull();
+    expect(
+      licenseRes['Unlicense'].dependencies[0].latestVersion,
+    ).not.toBeNull();
+
+    expect(licenseRes['Zlib']).toBeUndefined();
+    expect(licenseRes['ISC'].projects.length).toEqual(1);
+    expect(licenseRes['ISC'].dependencies[0].copyright).toEqual([
+      'Copyright (c) Isaac Z. Schlueter and Contributors',
+    ]);
+  }, 70000);
 
   test.todo('Test for when API fails aka bad org id provided');
 });

--- a/test/system/__snapshots__/generate.test.ts.snap
+++ b/test/system/__snapshots__/generate.test.ts.snap
@@ -16,6 +16,8 @@ Options:
   --view          How should the data be represented. Defaults to a license
                   based view.
      [choices: \\"org-licenses\\", \\"project-dependencies\\"] [default: \\"org-licenses\\"]
+  --project       Project ID to filter the results by. E.g. --project=uuid
+                  --project=uuid2                                  [default: []]
 
 Missing required argument: orgPublicId"
 `;

--- a/test/system/__snapshots__/json.test.ts.snap
+++ b/test/system/__snapshots__/json.test.ts.snap
@@ -10,6 +10,8 @@ Options:
   --version      Show version number                                   [boolean]
   --help         Show help                                             [boolean]
   --orgPublicId                                                       [required]
+  --project      Project ID to filter the results by. E.g. --project=uuid
+                 --project=uuid2                                   [default: []]
 
 Missing required argument: orgPublicId"
 `;

--- a/test/system/generate.test.ts
+++ b/test/system/generate.test.ts
@@ -8,7 +8,12 @@ describe('`snyk-licenses-report generate <...>`', () => {
   it('Shows error when missing --orgPublicId', async (done) => {
     exec(
       `node ${main} generate`,
-      { env: { SNYK_TOKEN: process.env.SNYK_TEST_TOKEN } },
+      {
+        env: {
+          PATH: process.env.PATH,
+          SNYK_TOKEN: process.env.SNYK_TEST_TOKEN,
+        },
+      },
       (err, stdout) => {
         expect(stdout).toBe('');
         expect(err.message.trim()).toMatchSnapshot();
@@ -20,7 +25,12 @@ describe('`snyk-licenses-report generate <...>`', () => {
   it('generated the report successfully with default params', (done) => {
     exec(
       `node ${main} generate --orgPublicId=${ORG_ID}`,
-      { env: { SNYK_TOKEN: process.env.SNYK_TEST_TOKEN } },
+      {
+        env: {
+          PATH: process.env.PATH,
+          SNYK_TOKEN: process.env.SNYK_TEST_TOKEN,
+        },
+      },
       (err, stdout) => {
         expect(err).toBeNull();
         expect(stdout).toMatch('HTML license report saved at');
@@ -32,7 +42,12 @@ describe('`snyk-licenses-report generate <...>`', () => {
   it.skip('generated the report successfully as PDF', (done) => {
     exec(
       `node ${main} generate --orgPublicId=${ORG_ID} --outputFormat=pdf`,
-      { env: { SNYK_TOKEN: process.env.SNYK_TEST_TOKEN } },
+      {
+        env: {
+          PATH: process.env.PATH,
+          SNYK_TOKEN: process.env.SNYK_TEST_TOKEN,
+        },
+      },
       (err, stdout) => {
         expect(err).toBeNull();
         expect(stdout).toMatch('PDF license report saved at');
@@ -42,8 +57,14 @@ describe('`snyk-licenses-report generate <...>`', () => {
   }, 50000);
   it('generated the report successfully with custom template', (done) => {
     exec(
-      `node ${main} generate --orgPublicId=${ORG_ID} --template=${__dirname + '/fixtures/custom-view.hbs'}`,
-      { env: { SNYK_TOKEN: process.env.SNYK_TEST_TOKEN } },
+      `node ${main} generate --orgPublicId=${ORG_ID} --template=${__dirname +
+        '/fixtures/custom-view.hbs'}`,
+      {
+        env: {
+          PATH: process.env.PATH,
+          SNYK_TOKEN: process.env.SNYK_TEST_TOKEN,
+        },
+      },
       (err, stdout) => {
         expect(err).toBeNull();
         expect(stdout).toMatch('HTML license report saved at');

--- a/test/system/json.test.ts
+++ b/test/system/json.test.ts
@@ -2,27 +2,55 @@ import { exec } from 'child_process';
 import { sep } from 'path';
 const main = './dist/index.js'.replace(/\//g, sep);
 const ORG_ID = process.env.TEST_ORG_ID as string;
+const PROJECT_ID = process.env.TEST_PROJECT_ID as string;
+
 describe('`snyk-licenses-report json <...>`', () => {
   it('Shows error when missing --orgPublicId', async (done) => {
     exec(
       `node ${main} json`,
-      { env: { SNYK_TOKEN: process.env.SNYK_TEST_TOKEN } },
+      {
+        env: {
+          PATH: process.env.PATH,
+          SNYK_TOKEN: process.env.SNYK_TEST_TOKEN,
+        },
+      },
       (err, stdout) => {
         expect(stdout).toBe('');
         expect(err.message.trim()).toMatchSnapshot();
         done();
       },
     );
-  });
+  }, 70000);
   it('Generated JSON data with correct --orgPublicId', async (done) => {
     exec(
       `node ${main} json --orgPublicId=${ORG_ID}`,
-      { env: { SNYK_TOKEN: process.env.SNYK_TEST_TOKEN } },
-      (err, stdout) => {
+      {
+        env: {
+          PATH: process.env.PATH,
+          SNYK_TOKEN: process.env.SNYK_TEST_TOKEN,
+        },
+      },
+      async (err, stdout) => {
         expect(err).toBeNull();
-        expect(stdout.trim()).toMatch('BSD-2-Clause');
+        expect(stdout).not.toBeNull();
         done();
       },
     );
-  }, 30000);
+  }, 70000);
+  it('Generated JSON data with correct --orgPublicId --project', async (done) => {
+    exec(
+      `node ${main} json --orgPublicId=${ORG_ID} --project=${PROJECT_ID}}`,
+      {
+        env: {
+          PATH: process.env.PATH,
+          SNYK_TOKEN: process.env.SNYK_TEST_TOKEN,
+        },
+      },
+      async (err, stdout) => {
+        expect(err).toBeNull();
+        expect(stdout).not.toBeNull();
+        done();
+      },
+    );
+  }, 70000);
 });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

 Allow to filter the report by a list of project Ids (both APIs used behind the scenes support filtering by projectIds string[])