### PR TITLE
fix: return actual filename

### DIFF
--- a/src/cmds/generate.ts
+++ b/src/cmds/generate.ts
@@ -50,7 +50,8 @@ export const builder = {
   },
   project: {
     default: [],
-    desc: 'Project ID to filter the results by. E.g. --project=uuid --project=uuid2',
+    desc:
+      'Project ID to filter the results by. E.g. --project=uuid --project=uuid2',
   },
 };
 export const aliases = ['g'];
@@ -97,12 +98,9 @@ export async function handler(argv: {
       orgData,
       view,
     )}.${outputFormat}`;
-    await generateReportFunc(reportFileName, reportData);
+    const { fileName } = await generateReportFunc(reportFileName, reportData);
     console.log(
-      `${outputFormat.toUpperCase()} license report saved at: ${pathLib.resolve(
-        __dirname,
-        reportFileName,
-      )}`,
+      `${outputFormat.toUpperCase()} license report saved at: ${fileName}`,
     );
   } catch (e) {
     console.error(e);

--- a/src/lib/generate-output/html/index.ts
+++ b/src/lib/generate-output/html/index.ts
@@ -9,7 +9,7 @@ const debug = debugLib('snyk-licenses:saveHtmlReport');
 export async function saveHtmlReport(
   fileName: string,
   data: string,
-): Promise<void> {
+): Promise<{ fileName: string }> {
   if (!data) {
     throw new Error('No report data to save!');
   }
@@ -17,4 +17,5 @@ export async function saveHtmlReport(
   debug(`⏳  Saving generated report to ${outputFile}`);
   writeContentsToFile(data, outputFile);
   debug(`✅ Saved HTML report to ${outputFile}`);
+  return { fileName: outputFile };
 }

--- a/src/lib/generate-output/pdf/index.ts
+++ b/src/lib/generate-output/pdf/index.ts
@@ -6,7 +6,7 @@ const debug = debugLib('snyk-licenses:generatePdfReport');
 export async function savePdfReport(
   fileName: string,
   data: string,
-): Promise<void> {
+): Promise<{ fileName: string }> {
   if (!data) {
     throw new Error('No report data to save!');
   }
@@ -19,4 +19,5 @@ export async function savePdfReport(
   await page.pdf({ path: fileName, format: 'A4' });
   await browser.close();
   debug(`✅ Saved PDF report to ${fileName}`);
+  return { fileName };
 }


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Return the filename and don't resolve again for saved reports