### PR TITLE
fix: licenses are not unique so accumulate their dependencies from API response

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,2 +1,1 @@
 14
-package-lock=false

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "node-fetch": "2.6.1",
     "puppeteer": "5.4.1",
     "snyk-api-ts-client": "1.5.2",
-    "snyk-config": "^3.0.0",
+    "snyk-config": "4.0.0",
     "source-map-support": "^0.5.16",
     "tslib": "2.0.3",
     "yargs": "16.0.3"

--- a/src/lib/generate-org-license-report.ts
+++ b/src/lib/generate-org-license-report.ts
@@ -64,11 +64,20 @@ export async function generateLicenseData(
         license.dependencies = dependenciesEnriched;
       }
       const licenseData = await getLicenseTextAndUrl(license.id);
-      licenseReportData[license.id] = {
-        ...(license as any),
-        licenseText: licenseData?.licenseText,
-        licenseUrl: licenseData?.licenseUrl,
-      };
+      if (licenseReportData[license.id]) {
+        licenseReportData[license.id].dependencies = {
+          ...licenseReportData[license.id].dependencies,
+          ...(license as any).dependencies,
+        };
+        licenseReportData[license.id].severities.push(license.severity)
+      } else {
+        licenseReportData[license.id] = {
+          ...(license as any),
+          licenseText: licenseData?.licenseText,
+          licenseUrl: licenseData?.licenseUrl,
+          severities: [license.severity]
+        };
+      }
     }
     debug(`✅ Done processing ${licenseData.total} licenses`);
 
@@ -93,7 +102,9 @@ function enrichDependencies(
         ...dep[0],
       });
     } else {
-      debug('Dep information not available from /dependencies API response for ' + dependency.id);
+      enrichDependencies.push({
+        ...dependency,
+      });
     }
   }
 

--- a/src/lib/generate-report/templates/licenses-view.hbs
+++ b/src/lib/generate-report/templates/licenses-view.hbs
@@ -146,10 +146,13 @@
     <h2>Organization: <a href="{{orgData.url}}">{{orgData.name}}</a></h2>
     {{#each licenses}}
     <div class="u-padding-top--sm">
-      <h1 class="license_title license_title--{{severity}}">
+      <h1>
         <a href="{{licenseUrl}}">{{id}}</a>
       </h1>
-      <strong>Severity</strong>: {{severity}}
+      <strong>Severities</strong>:
+      {{#each severities}}
+      "{{ this }}",
+      {{/each}}
       {{#if instructions}}
       <strong>Legal Instructions</strong>: {{instructions}}
       {{/if}}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,7 +6,7 @@ export interface Dependency {
 }
 
 export type LicenseSeverity = 'none' | 'high' | 'medium' | 'low';
-export type EnrichedDependency = Dependency & DependencyData;
+export type EnrichedDependency = Dependency & Partial<DependencyData>;
 
 export interface LicenseReportDataEntry {
   /**
@@ -37,6 +37,7 @@ export interface LicenseReportDataEntry {
   /**
    * Snyk projects from this org with dependencies using this license
    */
+  severities: string[];
   projects: {
     id: string;
     name: string;

--- a/test/lib/__snapshots__/fetch-spdx-license.test.ts.snap
+++ b/test/lib/__snapshots__/fetch-spdx-license.test.ts.snap
@@ -17,17 +17,17 @@ Object {
       
         
       
-      
+
       
         
           Software Package Data Exchange (SPDX)
-            
+        
       
-      
+
     
    
 
-    
+  
       
       
   
@@ -47,11 +47,16 @@ Object {
       Other web pages for this license
           
             
-             http://opensource.linux-mirror.org/licenses/afl-1.1.txt
-             http://wayback.archive.org/web/20021004124254/http://www.opensource.org/licenses/academic.php
+             
+               http://opensource.linux-mirror.org/licenses/afl-1.1.txt
+               
+             
+             
+               http://wayback.archive.org/web/20021004124254/http://www.opensource.org/licenses/academic.php [no longer live]
+             
            
           
-          
+
       true
 
       Notes

--- a/test/lib/__snapshots__/generate-html-report.test.ts.snap
+++ b/test/lib/__snapshots__/generate-html-report.test.ts.snap
@@ -147,10 +147,10 @@ exports[`Generate HTML report License HTML Report is generated as expected 1`] =
     <h1>Snyk Licenses Attribution Report</h1>
     <h2>Organization: <a href=\\"https://snyk.io/org/org\\">org</a></h2>
     <div class=\\"u-padding-top--sm\\">
-      <h1 class=\\"license_title license_title--medium\\">
+      <h1>
         <a href=\\"https://spdx.org/licenses/BSD-2-Clause.html\\">BSD-2-Clause</a>
       </h1>
-      <strong>Severity</strong>: medium
+      <strong>Severities</strong>:
       <strong>Legal Instructions</strong>: Do not use any package with this license without speaking to anna@legal.com
     </div>
 
@@ -337,10 +337,10 @@ THIS SOFTWARE IS PROVIDED BY <<var;name=\\"copyrightHolderAsIs\\";original=\\"TH
     </div>
     </div>
     <div class=\\"u-padding-top--sm\\">
-      <h1 class=\\"license_title license_title--high\\">
+      <h1>
         <a href=\\"\\">Unknown</a>
       </h1>
-      <strong>Severity</strong>: high
+      <strong>Severities</strong>:
       <strong>Legal Instructions</strong>: Any package with this license is not to be used.
     </div>
 
@@ -401,10 +401,10 @@ THIS SOFTWARE IS PROVIDED BY <<var;name=\\"copyrightHolderAsIs\\";original=\\"TH
     </div>
     </div>
     <div class=\\"u-padding-top--sm\\">
-      <h1 class=\\"license_title license_title--none\\">
+      <h1>
         <a href=\\"https://spdx.org/licenses/Unlicense.html\\">Unlicense</a>
       </h1>
-      <strong>Severity</strong>: none
+      <strong>Severities</strong>:
     </div>
 
     <div class=\\"display-flex border-right border-top border-bottom border-left u-margin-top--sm\\">

--- a/test/lib/generate-license-report-data.test.ts
+++ b/test/lib/generate-license-report-data.test.ts
@@ -37,7 +37,7 @@ describe('Get org licenses', () => {
     expect(licenseRes['ISC'].dependencies[0].copyright).toEqual(
       ['Copyright (c) Isaac Z. Schlueter and Contributors'],
     );
-  }, 70000);
+  }, 80000);
 
   test('License data is generated as expected', async () => {
     const licenseRes = await generateLicenseData(ORG_ID, {
@@ -46,6 +46,7 @@ describe('Get org licenses', () => {
       },
     });
     expect(Object.keys(licenseRes).length >= 11).toBeTruthy();
+    console.log(`licenseRes`, licenseRes)
     expect(licenseRes['Unknown']).toBeUndefined();
     expect(licenseRes['Unlicense'].licenseText).not.toBeNull();
     expect(licenseRes['Unlicense'].licenseUrl).toBe(
@@ -65,7 +66,7 @@ describe('Get org licenses', () => {
     expect(licenseRes['ISC'].dependencies[0].copyright).toEqual([
       'Copyright (c) Isaac Z. Schlueter and Contributors',
     ]);
-  }, 70000);
+  }, 80000);
 
   test.todo('Test for when API fails aka bad org id provided');
 });

--- a/test/system/json.test.ts
+++ b/test/system/json.test.ts
@@ -20,7 +20,7 @@ describe('`snyk-licenses-report json <...>`', () => {
         done();
       },
     );
-  }, 70000);
+  }, 80000);
   it('Generated JSON data with correct --orgPublicId', async (done) => {
     exec(
       `node ${main} json --orgPublicId=${ORG_ID}`,
@@ -36,7 +36,7 @@ describe('`snyk-licenses-report json <...>`', () => {
         done();
       },
     );
-  }, 70000);
+  }, 80000);
   it('Generated JSON data with correct --orgPublicId --project', async (done) => {
     exec(
       `node ${main} json --orgPublicId=${ORG_ID} --project=${PROJECT_ID}}`,
@@ -52,5 +52,5 @@ describe('`snyk-licenses-report json <...>`', () => {
         done();
       },
     );
-  }, 70000);
+  }, 80000);
 });


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Dual licenses are returned via API not squashed like in the UI, they will also have their own severity or not at all set. Accomodate for this as we were losing dependency data by overriding.