### PR TITLE
feat: exclude snyk fields in license view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@ dist
 package-lock.json
 yarn.lock
 .eslintcache
-*-org-licenses.html
-*-project-dependencies.html
+./*-org-licenses.html
+./*-project-dependencies.html

--- a/src/cmds/generate.ts
+++ b/src/cmds/generate.ts
@@ -42,6 +42,10 @@ export const builder = {
     desc: 'Report format',
     choices: [OutputFormat.HTML],
   },
+  excludeSnykFields: {
+    desc:
+      'Choose to exclude Snyk information. Excluded information: organization name, organization links, license severities in Snyk, license instructions, Snyk project information.',
+  },
   view: {
     choices: [SupportedViews.ORG_LICENSES, SupportedViews.PROJECT_DEPENDENCIES],
     default: SupportedViews.ORG_LICENSES,
@@ -56,15 +60,17 @@ export const builder = {
 };
 export const aliases = ['g'];
 
-export async function handler(argv: {
-  orgPublicId: string;
-  outputFormat: OutputFormat;
-  template: string;
-  view: SupportedViews;
-  project?: string | string[];
-}) {
+export async function handler(argv: GenerateOptions) {
   try {
-    const { orgPublicId, outputFormat, template, view, project } = argv;
+    validateOptions(argv);
+    const {
+      orgPublicId,
+      outputFormat,
+      template,
+      view,
+      project,
+      excludeSnykFields = false,
+    } = argv;
     debug(
       'ℹ️  Options: ' +
         JSON.stringify({
@@ -104,5 +110,22 @@ export async function handler(argv: {
     );
   } catch (e) {
     console.error(e.message || e);
+  }
+}
+
+interface GenerateOptions {
+  orgPublicId: string;
+  outputFormat: OutputFormat;
+  template: string;
+  view: SupportedViews;
+  project?: string | string[];
+  excludeSnykFields?: boolean;
+}
+function validateOptions(argv: GenerateOptions) {
+  const { view, excludeSnykFields = false } = argv;
+  if (excludeSnykFields && view === SupportedViews.PROJECT_DEPENDENCIES) {
+    throw new Error(
+      `--excludeSnykFields is not supported with with ${SupportedViews.PROJECT_DEPENDENCIES} view as Snyk project information is required`,
+    );
   }
 }

--- a/src/cmds/generate.ts
+++ b/src/cmds/generate.ts
@@ -98,6 +98,9 @@ export async function handler(argv: GenerateOptions) {
       orgData,
       template,
       view,
+      {
+        excludeSnykFields,
+      },
     );
     const generateReportFunc = outputHandlers[outputFormat];
     const reportFileName = `${generateReportName(

--- a/src/lib/generate-org-license-report.ts
+++ b/src/lib/generate-org-license-report.ts
@@ -34,6 +34,10 @@ export async function generateLicenseData(
 
   try {
     const licenseData = await getLicenseDataForOrg(orgPublicId, options);
+    if (!licenseData.total) {
+      debug(`ℹ️  Detected 0 licenses`);
+      throw new Error("No licenses returned from /licenses Snyk API. Please make sure the org has licenses configured and try again.");
+    }
     debug(`✅ Got license API data for Org:${orgPublicId}`);
     const dependenciesDataRaw = await getDependenciesDataForOrg(
       orgPublicId,

--- a/src/lib/generate-report/index.ts
+++ b/src/lib/generate-report/index.ts
@@ -22,6 +22,11 @@ export async function generateHtmlReport(
   orgData: OrgData,
   templateOverridePath: string | undefined = undefined,
   view: SupportedViews = SupportedViews.ORG_LICENSES,
+  options: {
+    excludeSnykFields: boolean;
+  } = {
+    excludeSnykFields: false,
+  },
 ): Promise<string> {
   debug('ℹ️  Generating HTML report');
   const hbsTemplate = selectTemplate(view, templateOverridePath);
@@ -30,10 +35,15 @@ export async function generateHtmlReport(
       hbsTemplate === DEFAULT_TEMPLATE ? 'default template' : hbsTemplate
     }`,
   );
-  debug(`ℹ️ Compiling Handlebars.js template ${hbsTemplate}`);
+  debug(`ℹ️  Compiling Handlebars.js template ${hbsTemplate}`);
   const htmlTemplate = await compileTemplate(hbsTemplate);
   debug(`✅ Compiled template ${hbsTemplate}`);
-  const transformedData = transformDataFunc[view](orgPublicId, data, orgData);
+  const transformedData = transformDataFunc[view](
+    orgPublicId,
+    data,
+    orgData,
+    options,
+  );
   return htmlTemplate(transformedData);
 }
 
@@ -41,12 +51,23 @@ function transformDataForLicenseView(
   orgPublicId: string,
   data: LicenseReportData,
   orgData: OrgData,
+  options: {
+    excludeSnykFields: boolean;
+  } = {
+    excludeSnykFields: false,
+  },
 ): {
   licenses: LicenseReportData;
   orgPublicId: string;
   orgData: OrgData;
+  includeSnykFields: boolean;
 } {
-  return { licenses: data, orgPublicId, orgData };
+  return {
+    licenses: data,
+    orgPublicId,
+    orgData,
+    includeSnykFields: !options.excludeSnykFields,
+  };
 }
 
 interface ProjectsReportData {

--- a/src/lib/generate-report/templates/licenses-view.hbs
+++ b/src/lib/generate-report/templates/licenses-view.hbs
@@ -31,6 +31,10 @@
       margin-top: .85em;
     }
 
+    .license-text {
+      white-space: pre-line;
+    }
+
     .banner-container {
       padding: 0 1.25rem;
     }
@@ -143,19 +147,23 @@
 
   <main class="u-padding--xl">
     <h1>Snyk Licenses Attribution Report</h1>
-    <h2>Organization: <a href="{{orgData.url}}">{{orgData.name}}</a></h2>
+    {{#if includeSnykFields}}
+      <h2>Organization: <a href="{{orgData.url}}">{{orgData.name}}</a></h2>
+    {{/if}}
     {{#each licenses}}
     <div class="u-padding-top--sm">
       <h1>
         <a href="{{licenseUrl}}">{{id}}</a>
       </h1>
-      <strong>Severities</strong>:
-      {{#each severities}}
-      "{{ this }}",
-      {{/each}}
-      {{#if instructions}}
-      <strong>Legal Instructions</strong>: {{instructions}}
-      {{/if}}
+      {{#if includeSnykFields}}
+        <strong>Severities</strong>:
+        {{#each severities}}
+        "{{ this }}",
+        {{/each}}
+        {{#if instructions}}
+        <strong>Legal Instructions</strong>: {{instructions}}
+        {{/if}}
+      {{/if }}
     </div>
 
     <div class="display-flex border-right border-top border-bottom border-left u-margin-top--sm">
@@ -189,6 +197,7 @@
           </div>
         </div>
       </div>
+      {{#if includeSnykFields}}
       <div class="column border-left">
         <div class="border-bottom u-padding--sm">
           <strong>Projects in Snyk</strong>
@@ -199,11 +208,12 @@
           {{/each}}
         </div>
       </div>
+      {{/if}}
       <div class="border-left overflow-auto">
         <div class="border-bottom u-padding--sm">
           <strong>License Text</strong>
         </div>
-        <div class="u-padding--sm">{{{licenseText}}}</div>
+        <div class="u-padding--sm license-text">{{{licenseText}}}</div>
       </div>
     </div>
     </div>

--- a/src/lib/generate-report/templates/licenses-view.hbs
+++ b/src/lib/generate-report/templates/licenses-view.hbs
@@ -155,7 +155,7 @@
       <h1>
         <a href="{{licenseUrl}}">{{id}}</a>
       </h1>
-      {{#if includeSnykFields}}
+      {{#if ../includeSnykFields}}
         <strong>Severities</strong>:
         {{#each severities}}
         "{{ this }}",
@@ -197,7 +197,7 @@
           </div>
         </div>
       </div>
-      {{#if includeSnykFields}}
+      {{#if ../includeSnykFields}}
       <div class="column border-left">
         <div class="border-bottom u-padding--sm">
           <strong>Projects in Snyk</strong>

--- a/test/lib/__snapshots__/generate-html-report.test.ts.snap
+++ b/test/lib/__snapshots__/generate-html-report.test.ts.snap
@@ -149,6 +149,752 @@ exports[`Generate HTML report License HTML Report is generated as expected 1`] =
 
   <main class=\\"u-padding--xl\\">
     <h1>Snyk Licenses Attribution Report</h1>
+      <h2>Organization: <a href=\\"https://snyk.io/org/org\\">org</a></h2>
+    <div class=\\"u-padding-top--sm\\">
+      <h1>
+        <a href=\\"https://spdx.org/licenses/BSD-2-Clause.html\\">BSD-2-Clause</a>
+      </h1>
+        <strong>Severities</strong>:
+        <strong>Legal Instructions</strong>: Do not use any package with this license without speaking to anna@legal.com
+    </div>
+
+    <div class=\\"display-flex border-right border-top border-bottom border-left u-margin-top--sm\\">
+      <div class=\\"column-large\\">
+        <div>
+          <div class=\\"display-flex\\">
+            <div class=\\"u-padding--sm dependency border-right\\">
+              <strong>Dependencies</strong>
+            </div>
+            <div class=\\"u-padding--sm\\">
+              <strong>Copyrights</strong>
+            </div>
+          </div>
+
+          <div>
+            <div class=\\"display-flex border-top\\">
+              <div class=\\"u-padding--sm dependency\\">
+                configstore@5.0.1
+              </div>
+              <div class=\\"u-padding--sm overflow-auto\\">
+                <div class=\\"u-padding-top--sm overflow-auto\\">
+                  Copyright (c) Google
+                </div>
+              </div>
+            </div>
+
+          </div>
+        </div>
+      </div>
+      <div class=\\"column border-left\\">
+        <div class=\\"border-bottom u-padding--sm\\">
+          <strong>Projects in Snyk</strong>
+        </div>
+        <div class=\\"u-padding--sm\\">
+          <a class=\\"u-padding-top--sm\\" href=\\"https://snyk.io/org/org/project/XXXX\\">snyk-fixtures/npm-with-single-dep:package.json</a><br>
+        </div>
+      </div>
+      <div class=\\"border-left overflow-auto\\">
+        <div class=\\"border-bottom u-padding--sm\\">
+          <strong>License Text</strong>
+        </div>
+        <div class=\\"u-padding--sm license-text\\">
+
+  
+    
+      
+        Linux Foundation Collaborative Projects
+      
+    
+  
+
+  
+    
+      
+        
+      
+      
+      
+        
+          Software Package Data Exchange (SPDX)
+            
+      
+      
+    
+   
+
+    
+      
+      
+  
+
+    
+
+      Home » Licenses
+
+      BSD 2-Clause \\"Simplified\\" License
+      false
+      Full name
+          BSD 2-Clause \\"Simplified\\" License
+
+      Short identifier
+          BSD-2-Clause
+
+      Other web pages for this license
+          
+            
+             https://opensource.org/licenses/BSD-2-Clause
+           
+          
+          
+      true
+
+      Notes
+          None
+
+      Text
+
+      
+      
+      
+
+         Copyright (c) <year> <owner>. All rights reserved.
+      
+
+      
+
+      Redistribution and use in source and binary forms, with or without modification, are permitted provided
+         that the following conditions are met:
+
+      
+
+
+            
+1.
+          Redistributions of source code must retain the above copyright notice, this list of conditions
+             and the following disclaimer.
+        
+
+            
+2.
+          Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+             and the following disclaimer in the documentation and/or other materials provided with the
+             distribution.
+        
+
+      THIS SOFTWARE IS PROVIDED BY
+        
+THE COPYRIGHT HOLDERS AND CONTRIBUTORS \\"AS IS\\" AND ANY
+        
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+        AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+        
+THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+        ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+        LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+        INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+        TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+        ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+      
+
+    
+      
+
+      Standard License Header
+      
+        There is no standard license header for the license
+        
+      
+      
+      <<var;name=\\"copyright\\";original=\\"Copyright (c) <year> <owner>. All rights reserved.\\";match=\\".{0,1000}\\">>
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+   <<var;name=\\"bullet\\";original=\\"1.\\";match=\\".{0,20}\\">> Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+   <<var;name=\\"bullet\\";original=\\"2.\\";match=\\".{0,20}\\">> Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY <<var;name=\\"copyrightHolderAsIs\\";original=\\"THE COPYRIGHT HOLDERS AND CONTRIBUTORS\\";match=\\".+\\">> \\"AS IS\\" AND ANY <<var;name=\\"express\\";original=\\"EXPRESS\\";match=\\"EXPRESS(ED)?\\">> OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL <<var;name=\\"copyrightHolderLiability\\";original=\\"THE COPYRIGHT HOLDER OR CONTRIBUTORS\\";match=\\".+\\">> BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+      
+
+     
+
+    
+      
+        
+          
+            © 2018          SPDX Workgroup a Linux Foundation Project. All Rights Reserved.        
+            Linux Foundation is a registered trademark of The Linux Foundation. Linux is a registered trademark of Linus Torvalds.
+            Please see our privacy policy and terms of use.
+          
+        
+      
+    
+
+    
+      top of page
+    
+
+  
+
+</div>
+      </div>
+    </div>
+    </div>
+    <div class=\\"u-padding-top--sm\\">
+      <h1>
+        <a href=\\"\\">Unknown</a>
+      </h1>
+        <strong>Severities</strong>:
+        <strong>Legal Instructions</strong>: Any package with this license is not to be used.
+    </div>
+
+    <div class=\\"display-flex border-right border-top border-bottom border-left u-margin-top--sm\\">
+      <div class=\\"column-large\\">
+        <div>
+          <div class=\\"display-flex\\">
+            <div class=\\"u-padding--sm dependency border-right\\">
+              <strong>Dependencies</strong>
+            </div>
+            <div class=\\"u-padding--sm\\">
+              <strong>Copyrights</strong>
+            </div>
+          </div>
+
+          <div>
+            <div class=\\"display-flex border-top\\">
+              <div class=\\"u-padding--sm dependency\\">
+                axis:axis-jaxrpc@1.4
+              </div>
+              <div class=\\"u-padding--sm overflow-auto\\">
+              </div>
+            </div>
+
+            <div class=\\"display-flex border-top\\">
+              <div class=\\"u-padding--sm dependency\\">
+                axis:axis-saaj@1.4
+              </div>
+              <div class=\\"u-padding--sm overflow-auto\\">
+              </div>
+            </div>
+
+            <div class=\\"display-flex border-top\\">
+              <div class=\\"u-padding--sm dependency\\">
+                axis:axis-wsdl4j@1.5.1
+              </div>
+              <div class=\\"u-padding--sm overflow-auto\\">
+              </div>
+            </div>
+
+          </div>
+        </div>
+      </div>
+      <div class=\\"column border-left\\">
+        <div class=\\"border-bottom u-padding--sm\\">
+          <strong>Projects in Snyk</strong>
+        </div>
+        <div class=\\"u-padding--sm\\">
+          <a class=\\"u-padding-top--sm\\" href=\\"https://snyk.io/org/org/project/XXX\\">snyk-fixtures/tiny-monorepo:gradle/build.gradle</a><br>
+        </div>
+      </div>
+      <div class=\\"border-left overflow-auto\\">
+        <div class=\\"border-bottom u-padding--sm\\">
+          <strong>License Text</strong>
+        </div>
+        <div class=\\"u-padding--sm license-text\\"></div>
+      </div>
+    </div>
+    </div>
+    <div class=\\"u-padding-top--sm\\">
+      <h1>
+        <a href=\\"https://spdx.org/licenses/Unlicense.html\\">Unlicense</a>
+      </h1>
+        <strong>Severities</strong>:
+    </div>
+
+    <div class=\\"display-flex border-right border-top border-bottom border-left u-margin-top--sm\\">
+      <div class=\\"column-large\\">
+        <div>
+          <div class=\\"display-flex\\">
+            <div class=\\"u-padding--sm dependency border-right\\">
+              <strong>Dependencies</strong>
+            </div>
+            <div class=\\"u-padding--sm\\">
+              <strong>Copyrights</strong>
+            </div>
+          </div>
+
+          <div>
+            <div class=\\"display-flex border-top\\">
+              <div class=\\"u-padding--sm dependency\\">
+                tweetnacl@0.14.5
+              </div>
+              <div class=\\"u-padding--sm overflow-auto\\">
+              </div>
+            </div>
+
+          </div>
+        </div>
+      </div>
+      <div class=\\"column border-left\\">
+        <div class=\\"border-bottom u-padding--sm\\">
+          <strong>Projects in Snyk</strong>
+        </div>
+        <div class=\\"u-padding--sm\\">
+          <a class=\\"u-padding-top--sm\\" href=\\"https://snyk.io/org/org/project/XXX\\">snyk-fixtures/npm-with-single-dep:package.json</a><br>
+        </div>
+      </div>
+      <div class=\\"border-left overflow-auto\\">
+        <div class=\\"border-bottom u-padding--sm\\">
+          <strong>License Text</strong>
+        </div>
+        <div class=\\"u-padding--sm license-text\\">
+
+  
+    
+      
+        Linux Foundation Collaborative Projects
+      
+    
+  
+
+  
+    
+      
+        
+      
+      
+      
+        
+          Software Package Data Exchange (SPDX)
+            
+      
+      
+    
+   
+
+    
+      
+      
+  
+
+    
+
+      Home » Licenses
+
+      The Unlicense
+      false
+      Full name
+          The Unlicense
+
+      Short identifier
+          Unlicense
+
+      Other web pages for this license
+          
+            
+             https://unlicense.org/
+           
+          
+          
+      true
+
+      Notes
+          This is a public domain dedication
+
+      Text
+
+      
+      
+      This is free and unencumbered software released into the public domain.
+
+      Anyone is free to copy, modify, publish, use, compile, sell, or distribute this software, either in
+         source code form or as a compiled binary, for any purpose, commercial or non-commercial, and by any
+         means.
+
+      In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and
+         all copyright interest in the software to the public domain. We make this dedication for the benefit
+         of the public at large and to the detriment of our heirs and
+        successors. We intend this dedication to be an overt act of relinquishment in perpetuity of all
+             present and future rights to this software under copyright law.
+      
+
+      THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+         LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+         NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+         OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+         OTHER DEALINGS IN THE SOFTWARE.
+
+      For more information, please refer to <https://unlicense.org/>
+
+    
+      
+
+      Standard License Header
+      
+        There is no standard license header for the license
+        
+      
+      
+      This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this software, either in source code form or as a compiled binary, for any purpose, commercial or non-commercial, and by any means.
+
+In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain. We make this dedication for the benefit of the public at large and to the detriment of our heirs and successors. We intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
+
+THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.<<beginOptional>> For more information, please refer to <https://unlicense.org/><<endOptional>>
+      
+
+     
+
+    
+      
+        
+          
+            © 2018          SPDX Workgroup a Linux Foundation Project. All Rights Reserved.        
+            Linux Foundation is a registered trademark of The Linux Foundation. Linux is a registered trademark of Linus Torvalds.
+            Please see our privacy policy and terms of use.
+          
+        
+      
+    
+
+    
+      top of page
+    
+
+  
+
+</div>
+      </div>
+    </div>
+    </div>
+  </main>
+</body>
+
+</html>
+"
+`;
+
+exports[`Generate HTML report License HTML Report is generated as expected with a custom hbs template 1`] = `
+"<!DOCTYPE html>
+<html lang=\\"en\\">
+
+<head>
+  <meta http-equiv=\\"Content-type\\" content=\\"text/html; charset=utf-8\\">
+  <meta http-equiv=\\"Content-Language\\" content=\\"en-us\\">
+  <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
+  <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=edge\\">
+  <title>Snyk Licenses Report</title>
+  <link rel=\\"icon\\" type=\\"image/png\\" href=\\"https://res.cloudinary.com/snyk/image/upload/v1468845142/favicon/favicon.png\\"
+    sizes=\\"194x194\\">
+  <link rel=\\"shortcut icon\\" href=\\"https://res.cloudinary.com/snyk/image/upload/v1468845142/favicon/favicon.ico\\">
+  <style type=\\"text/css\\">
+    body {
+      margin: 0;
+      padding: 0;
+      font-weight: 400;
+    }
+
+    a {
+      color: #4b45a1;
+    }
+
+    h1,
+    h2 {
+      color: #393842;
+    }
+
+    .banner-logo {
+      padding-right: 2%;
+      margin-top: .85em;
+    }
+
+    .banner-container {
+      padding: 0 1.25rem;
+    }
+
+    .banner {
+      height: 4.0625rem;
+      padding: .75rem 0;
+    }
+
+    .banner {
+      background-color: #4b45a9;
+      padding: .625rem 0;
+      position: relative;
+      z-index: 1000;
+    }
+
+    .border-bottom {
+      border-bottom: 1px solid #ccc;
+    }
+
+    .border-top {
+      border-top: 1px solid #ccc;
+    }
+
+    .border-left {
+      border-left: 1px solid #ccc;
+    }
+
+    .border-right {
+      border-right: 1px solid #ccc;
+    }
+
+    .license_title {
+      border-left: .5rem solid #ccc;
+      padding: 4px;
+    }
+
+    .license_title--medium {
+      border-left-color: #df8620;
+    }
+
+    .license_title--high {
+      border-left-color: #b31a6b;
+    }
+
+    .display-flex {
+      display: flex;
+      max-width: 100%;
+    }
+
+    .column {
+      flex: 1 0 150px;
+      max-width: 100%;
+    }
+
+    .column-large {
+      flex: 1 0 300px;
+      max-width: 100%;
+    }
+
+    .dependency {
+      flex: 0 0 30%;
+      max-width: 100%;
+      word-break: break-all;
+    }
+
+    .u-padding-top--sm {
+      padding-top: .5rem;
+    }
+
+    .u-margin-top--sm {
+      margin-top: .5rem;
+    }
+
+    .u-padding--sm {
+      padding: .5rem;
+    }
+
+    .u-padding--xl {
+      padding: 2rem;
+    }
+
+    .overflow-auto {
+      overflow: auto;
+    }
+  </style>
+</head>
+
+<body>
+  <header id=\\"banner\\" class=\\"banner\\">
+    <div class=\\"banner-container\\">
+      <div class=\\"banner-logo\\">
+        <a class=\\"brand\\" href=\\"https://www.snyk.io\\" title=\\"Snyk\\">
+          <svg width=\\"68px\\" height=\\"35px\\" viewBox=\\"0 0 68 35\\" version=\\"1.1\\" xmlns=\\"http://www.w3.org/2000/svg\\"
+            role=\\"img\\">
+            <title>Snyk - Open Source Security</title>
+            <g stroke=\\"none\\" stroke-width=\\"1\\" fill=\\"none\\" fill-rule=\\"evenodd\\">
+              <g fill=\\"#fff\\">
+                <path
+                  d=\\"M5.732,27.278 C3.445,27.278 1.589,26.885 0,26.124 L0.483,22.472 C2.163,23.296 4.056,23.689 5.643,23.689 C6.801,23.689 7.563,23.295 7.563,22.599 C7.563,20.594 0.333,21.076 0.333,15.839 C0.333,12.491 3.407,10.729 7.259,10.729 C9.179,10.729 11.161,11.249 12.444,11.704 L11.924,15.294 C10.577,14.774 8.747,14.291 7.222,14.291 C6.282,14.291 5.518,14.621 5.518,15.231 C5.518,17.208 12.903,16.815 12.903,21.925 C12.903,25.325 9.877,27.277 5.733,27.277 L5.732,27.278 Z M25.726,26.936 L25.726,17.894 C25.726,15.827 24.811,14.85 23.069,14.85 C22.219,14.85 21.329,15.09 20.719,15.46 L20.719,26.936 L15.352,26.936 L15.352,11.262 L20.602,10.83 L20.474,13.392 L20.652,13.392 C21.784,11.87 23.702,10.716 25.992,10.716 C28.736,10.716 31.112,12.416 31.112,16.436 L31.112,26.936 L25.724,26.936 L25.726,26.936 Z M61.175,26.936 L56.879,19.479 L56.446,19.479 L56.446,26.935 L51.082,26.935 L51.082,8.37 L56.447,0 L56.447,17.323 C57.515,16.017 61.112,11.059 61.112,11.059 L67.732,11.059 L61.454,17.689 L67.949,26.95 L61.175,26.95 L61.175,26.938 L61.175,26.936 Z M44.13,11.11 L41.93,18.262 C41.5,19.606 41.08,22.079 41.08,22.079 C41.08,22.079 40.75,19.516 40.292,18.172 L37.94,11.108 L31.928,11.108 L38.462,26.935 C37.572,29.04 36.199,30.815 34.369,30.815 C34.039,30.815 33.709,30.802 33.389,30.765 L31.255,34.061 C31.928,34.441 33.212,34.835 34.737,34.835 C38.703,34.835 41.359,31.627 43.215,26.885 L49.443,11.108 L44.132,11.108 L44.13,11.11 Z\\">
+                </path>
+              </g>
+            </g>
+          </svg>
+        </a>
+      </div>
+    </div>
+  </header>
+
+  <main class=\\"u-padding--xl\\">
+    <h1>Custom Template Licenses Attribution Report</h1>
+    <h2>Organization: <a href=\\"https://snyk.io/org/org\\">org</a></h2>
+    <div class=\\"u-padding-top--sm\\">
+      <h1 class=\\"license_title license_title--medium\\">
+        <a href=\\"https://spdx.org/licenses/BSD-2-Clause.html\\">BSD-2-Clause</a>
+      </h1>
+      <strong>Severity</strong>: medium
+    </div>
+    <div class=\\"u-padding-top--sm\\">
+      <h1 class=\\"license_title license_title--high\\">
+        <a href=\\"\\">Unknown</a>
+      </h1>
+      <strong>Severity</strong>: high
+    </div>
+    <div class=\\"u-padding-top--sm\\">
+      <h1 class=\\"license_title license_title--none\\">
+        <a href=\\"https://spdx.org/licenses/Unlicense.html\\">Unlicense</a>
+      </h1>
+      <strong>Severity</strong>: none
+    </div>
+  </main>
+</body>
+
+</html>
+"
+`;
+
+exports[`Generate HTML report License HTML Report is generated as expected with excludeSnykFields enabled 1`] = `
+"<!DOCTYPE html>
+<html lang=\\"en\\">
+
+<head>
+  <meta http-equiv=\\"Content-type\\" content=\\"text/html; charset=utf-8\\">
+  <meta http-equiv=\\"Content-Language\\" content=\\"en-us\\">
+  <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
+  <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=edge\\">
+  <title>Snyk Licenses Report</title>
+  <link rel=\\"icon\\" type=\\"image/png\\" href=\\"https://res.cloudinary.com/snyk/image/upload/v1468845142/favicon/favicon.png\\"
+    sizes=\\"194x194\\">
+  <link rel=\\"shortcut icon\\" href=\\"https://res.cloudinary.com/snyk/image/upload/v1468845142/favicon/favicon.ico\\">
+  <style type=\\"text/css\\">
+    body {
+      margin: 0;
+      padding: 0;
+      font-weight: 400;
+    }
+
+    a {
+      color: #4b45a1;
+    }
+
+    h1,
+    h2 {
+      color: #393842;
+    }
+
+    .banner-logo {
+      padding-right: 2%;
+      margin-top: .85em;
+    }
+
+    .license-text {
+      white-space: pre-line;
+    }
+
+    .banner-container {
+      padding: 0 1.25rem;
+    }
+
+    .banner {
+      height: 4.0625rem;
+      padding: .75rem 0;
+    }
+
+    .banner {
+      background-color: #4b45a9;
+      padding: .625rem 0;
+      position: relative;
+      z-index: 1000;
+    }
+
+    .border-bottom {
+      border-bottom: 1px solid #ccc;
+    }
+
+    .border-top {
+      border-top: 1px solid #ccc;
+    }
+
+    .border-left {
+      border-left: 1px solid #ccc;
+    }
+
+    .border-right {
+      border-right: 1px solid #ccc;
+    }
+
+    .license_title {
+      border-left: .5rem solid #ccc;
+      padding: 4px;
+    }
+
+    .license_title--medium {
+      border-left-color: #df8620;
+    }
+
+    .license_title--high {
+      border-left-color: #b31a6b;
+    }
+
+    .display-flex {
+      display: flex;
+      max-width: 100%;
+    }
+
+    .column {
+      flex: 1 0 150px;
+      max-width: 100%;
+    }
+
+    .column-large {
+      flex: 1 0 320px;
+      max-width: 100%;
+    }
+
+    .dependency {
+      flex: 0 0 30%;
+      max-width: 100%;
+      word-break: break-all;
+    }
+
+    .u-padding-top--sm {
+      padding-top: .5rem;
+    }
+
+    .u-margin-top--sm {
+      margin-top: .5rem;
+    }
+
+    .u-padding--sm {
+      padding: .5rem;
+    }
+
+    .u-padding--xl {
+      padding: 2rem;
+    }
+
+    .overflow-auto {
+      overflow: auto;
+    }
+  </style>
+</head>
+
+<body>
+  <header id=\\"banner\\" class=\\"banner\\">
+    <div class=\\"banner-container\\">
+      <div class=\\"banner-logo\\">
+        <a class=\\"brand\\" href=\\"https://www.snyk.io\\" title=\\"Snyk\\">
+          <svg width=\\"68px\\" height=\\"35px\\" viewBox=\\"0 0 68 35\\" version=\\"1.1\\" xmlns=\\"http://www.w3.org/2000/svg\\"
+            role=\\"img\\">
+            <title>Snyk - Open Source Security</title>
+            <g stroke=\\"none\\" stroke-width=\\"1\\" fill=\\"none\\" fill-rule=\\"evenodd\\">
+              <g fill=\\"#fff\\">
+                <path
+                  d=\\"M5.732,27.278 C3.445,27.278 1.589,26.885 0,26.124 L0.483,22.472 C2.163,23.296 4.056,23.689 5.643,23.689 C6.801,23.689 7.563,23.295 7.563,22.599 C7.563,20.594 0.333,21.076 0.333,15.839 C0.333,12.491 3.407,10.729 7.259,10.729 C9.179,10.729 11.161,11.249 12.444,11.704 L11.924,15.294 C10.577,14.774 8.747,14.291 7.222,14.291 C6.282,14.291 5.518,14.621 5.518,15.231 C5.518,17.208 12.903,16.815 12.903,21.925 C12.903,25.325 9.877,27.277 5.733,27.277 L5.732,27.278 Z M25.726,26.936 L25.726,17.894 C25.726,15.827 24.811,14.85 23.069,14.85 C22.219,14.85 21.329,15.09 20.719,15.46 L20.719,26.936 L15.352,26.936 L15.352,11.262 L20.602,10.83 L20.474,13.392 L20.652,13.392 C21.784,11.87 23.702,10.716 25.992,10.716 C28.736,10.716 31.112,12.416 31.112,16.436 L31.112,26.936 L25.724,26.936 L25.726,26.936 Z M61.175,26.936 L56.879,19.479 L56.446,19.479 L56.446,26.935 L51.082,26.935 L51.082,8.37 L56.447,0 L56.447,17.323 C57.515,16.017 61.112,11.059 61.112,11.059 L67.732,11.059 L61.454,17.689 L67.949,26.95 L61.175,26.95 L61.175,26.938 L61.175,26.936 Z M44.13,11.11 L41.93,18.262 C41.5,19.606 41.08,22.079 41.08,22.079 C41.08,22.079 40.75,19.516 40.292,18.172 L37.94,11.108 L31.928,11.108 L38.462,26.935 C37.572,29.04 36.199,30.815 34.369,30.815 C34.039,30.815 33.709,30.802 33.389,30.765 L31.255,34.061 C31.928,34.441 33.212,34.835 34.737,34.835 C38.703,34.835 41.359,31.627 43.215,26.885 L49.443,11.108 L44.132,11.108 L44.13,11.11 Z\\">
+                </path>
+              </g>
+            </g>
+          </svg>
+        </a>
+      </div>
+    </div>
+  </header>
+
+  <main class=\\"u-padding--xl\\">
+    <h1>Snyk Licenses Attribution Report</h1>
     <div class=\\"u-padding-top--sm\\">
       <h1>
         <a href=\\"https://spdx.org/licenses/BSD-2-Clause.html\\">BSD-2-Clause</a>
@@ -537,177 +1283,6 @@ THE SOFTWARE IS PROVIDED \\"AS IS\\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
 </div>
       </div>
     </div>
-    </div>
-  </main>
-</body>
-
-</html>
-"
-`;
-
-exports[`Generate HTML report License HTML Report is generated as expected with a custom hbs template 1`] = `
-"<!DOCTYPE html>
-<html lang=\\"en\\">
-
-<head>
-  <meta http-equiv=\\"Content-type\\" content=\\"text/html; charset=utf-8\\">
-  <meta http-equiv=\\"Content-Language\\" content=\\"en-us\\">
-  <meta name=\\"viewport\\" content=\\"width=device-width, initial-scale=1.0\\">
-  <meta http-equiv=\\"X-UA-Compatible\\" content=\\"IE=edge\\">
-  <title>Snyk Licenses Report</title>
-  <link rel=\\"icon\\" type=\\"image/png\\" href=\\"https://res.cloudinary.com/snyk/image/upload/v1468845142/favicon/favicon.png\\"
-    sizes=\\"194x194\\">
-  <link rel=\\"shortcut icon\\" href=\\"https://res.cloudinary.com/snyk/image/upload/v1468845142/favicon/favicon.ico\\">
-  <style type=\\"text/css\\">
-    body {
-      margin: 0;
-      padding: 0;
-      font-weight: 400;
-    }
-
-    a {
-      color: #4b45a1;
-    }
-
-    h1,
-    h2 {
-      color: #393842;
-    }
-
-    .banner-logo {
-      padding-right: 2%;
-      margin-top: .85em;
-    }
-
-    .banner-container {
-      padding: 0 1.25rem;
-    }
-
-    .banner {
-      height: 4.0625rem;
-      padding: .75rem 0;
-    }
-
-    .banner {
-      background-color: #4b45a9;
-      padding: .625rem 0;
-      position: relative;
-      z-index: 1000;
-    }
-
-    .border-bottom {
-      border-bottom: 1px solid #ccc;
-    }
-
-    .border-top {
-      border-top: 1px solid #ccc;
-    }
-
-    .border-left {
-      border-left: 1px solid #ccc;
-    }
-
-    .border-right {
-      border-right: 1px solid #ccc;
-    }
-
-    .license_title {
-      border-left: .5rem solid #ccc;
-      padding: 4px;
-    }
-
-    .license_title--medium {
-      border-left-color: #df8620;
-    }
-
-    .license_title--high {
-      border-left-color: #b31a6b;
-    }
-
-    .display-flex {
-      display: flex;
-      max-width: 100%;
-    }
-
-    .column {
-      flex: 1 0 150px;
-      max-width: 100%;
-    }
-
-    .column-large {
-      flex: 1 0 300px;
-      max-width: 100%;
-    }
-
-    .dependency {
-      flex: 0 0 30%;
-      max-width: 100%;
-      word-break: break-all;
-    }
-
-    .u-padding-top--sm {
-      padding-top: .5rem;
-    }
-
-    .u-margin-top--sm {
-      margin-top: .5rem;
-    }
-
-    .u-padding--sm {
-      padding: .5rem;
-    }
-
-    .u-padding--xl {
-      padding: 2rem;
-    }
-
-    .overflow-auto {
-      overflow: auto;
-    }
-  </style>
-</head>
-
-<body>
-  <header id=\\"banner\\" class=\\"banner\\">
-    <div class=\\"banner-container\\">
-      <div class=\\"banner-logo\\">
-        <a class=\\"brand\\" href=\\"https://www.snyk.io\\" title=\\"Snyk\\">
-          <svg width=\\"68px\\" height=\\"35px\\" viewBox=\\"0 0 68 35\\" version=\\"1.1\\" xmlns=\\"http://www.w3.org/2000/svg\\"
-            role=\\"img\\">
-            <title>Snyk - Open Source Security</title>
-            <g stroke=\\"none\\" stroke-width=\\"1\\" fill=\\"none\\" fill-rule=\\"evenodd\\">
-              <g fill=\\"#fff\\">
-                <path
-                  d=\\"M5.732,27.278 C3.445,27.278 1.589,26.885 0,26.124 L0.483,22.472 C2.163,23.296 4.056,23.689 5.643,23.689 C6.801,23.689 7.563,23.295 7.563,22.599 C7.563,20.594 0.333,21.076 0.333,15.839 C0.333,12.491 3.407,10.729 7.259,10.729 C9.179,10.729 11.161,11.249 12.444,11.704 L11.924,15.294 C10.577,14.774 8.747,14.291 7.222,14.291 C6.282,14.291 5.518,14.621 5.518,15.231 C5.518,17.208 12.903,16.815 12.903,21.925 C12.903,25.325 9.877,27.277 5.733,27.277 L5.732,27.278 Z M25.726,26.936 L25.726,17.894 C25.726,15.827 24.811,14.85 23.069,14.85 C22.219,14.85 21.329,15.09 20.719,15.46 L20.719,26.936 L15.352,26.936 L15.352,11.262 L20.602,10.83 L20.474,13.392 L20.652,13.392 C21.784,11.87 23.702,10.716 25.992,10.716 C28.736,10.716 31.112,12.416 31.112,16.436 L31.112,26.936 L25.724,26.936 L25.726,26.936 Z M61.175,26.936 L56.879,19.479 L56.446,19.479 L56.446,26.935 L51.082,26.935 L51.082,8.37 L56.447,0 L56.447,17.323 C57.515,16.017 61.112,11.059 61.112,11.059 L67.732,11.059 L61.454,17.689 L67.949,26.95 L61.175,26.95 L61.175,26.938 L61.175,26.936 Z M44.13,11.11 L41.93,18.262 C41.5,19.606 41.08,22.079 41.08,22.079 C41.08,22.079 40.75,19.516 40.292,18.172 L37.94,11.108 L31.928,11.108 L38.462,26.935 C37.572,29.04 36.199,30.815 34.369,30.815 C34.039,30.815 33.709,30.802 33.389,30.765 L31.255,34.061 C31.928,34.441 33.212,34.835 34.737,34.835 C38.703,34.835 41.359,31.627 43.215,26.885 L49.443,11.108 L44.132,11.108 L44.13,11.11 Z\\">
-                </path>
-              </g>
-            </g>
-          </svg>
-        </a>
-      </div>
-    </div>
-  </header>
-
-  <main class=\\"u-padding--xl\\">
-    <h1>Custom Template Licenses Attribution Report</h1>
-    <h2>Organization: <a href=\\"https://snyk.io/org/org\\">org</a></h2>
-    <div class=\\"u-padding-top--sm\\">
-      <h1 class=\\"license_title license_title--medium\\">
-        <a href=\\"https://spdx.org/licenses/BSD-2-Clause.html\\">BSD-2-Clause</a>
-      </h1>
-      <strong>Severity</strong>: medium
-    </div>
-    <div class=\\"u-padding-top--sm\\">
-      <h1 class=\\"license_title license_title--high\\">
-        <a href=\\"\\">Unknown</a>
-      </h1>
-      <strong>Severity</strong>: high
-    </div>
-    <div class=\\"u-padding-top--sm\\">
-      <h1 class=\\"license_title license_title--none\\">
-        <a href=\\"https://spdx.org/licenses/Unlicense.html\\">Unlicense</a>
-      </h1>
-      <strong>Severity</strong>: none
     </div>
   </main>
 </body>

--- a/test/lib/__snapshots__/generate-html-report.test.ts.snap
+++ b/test/lib/__snapshots__/generate-html-report.test.ts.snap
@@ -34,6 +34,10 @@ exports[`Generate HTML report License HTML Report is generated as expected 1`] =
       margin-top: .85em;
     }
 
+    .license-text {
+      white-space: pre-line;
+    }
+
     .banner-container {
       padding: 0 1.25rem;
     }
@@ -145,13 +149,10 @@ exports[`Generate HTML report License HTML Report is generated as expected 1`] =
 
   <main class=\\"u-padding--xl\\">
     <h1>Snyk Licenses Attribution Report</h1>
-    <h2>Organization: <a href=\\"https://snyk.io/org/org\\">org</a></h2>
     <div class=\\"u-padding-top--sm\\">
       <h1>
         <a href=\\"https://spdx.org/licenses/BSD-2-Clause.html\\">BSD-2-Clause</a>
       </h1>
-      <strong>Severities</strong>:
-      <strong>Legal Instructions</strong>: Do not use any package with this license without speaking to anna@legal.com
     </div>
 
     <div class=\\"display-flex border-right border-top border-bottom border-left u-margin-top--sm\\">
@@ -181,19 +182,11 @@ exports[`Generate HTML report License HTML Report is generated as expected 1`] =
           </div>
         </div>
       </div>
-      <div class=\\"column border-left\\">
-        <div class=\\"border-bottom u-padding--sm\\">
-          <strong>Projects in Snyk</strong>
-        </div>
-        <div class=\\"u-padding--sm\\">
-          <a class=\\"u-padding-top--sm\\" href=\\"https://snyk.io/org/org/project/XXXX\\">snyk-fixtures/npm-with-single-dep:package.json</a><br>
-        </div>
-      </div>
       <div class=\\"border-left overflow-auto\\">
         <div class=\\"border-bottom u-padding--sm\\">
           <strong>License Text</strong>
         </div>
-        <div class=\\"u-padding--sm\\">
+        <div class=\\"u-padding--sm license-text\\">
 
   
     
@@ -340,8 +333,6 @@ THIS SOFTWARE IS PROVIDED BY <<var;name=\\"copyrightHolderAsIs\\";original=\\"TH
       <h1>
         <a href=\\"\\">Unknown</a>
       </h1>
-      <strong>Severities</strong>:
-      <strong>Legal Instructions</strong>: Any package with this license is not to be used.
     </div>
 
     <div class=\\"display-flex border-right border-top border-bottom border-left u-margin-top--sm\\">
@@ -384,19 +375,11 @@ THIS SOFTWARE IS PROVIDED BY <<var;name=\\"copyrightHolderAsIs\\";original=\\"TH
           </div>
         </div>
       </div>
-      <div class=\\"column border-left\\">
-        <div class=\\"border-bottom u-padding--sm\\">
-          <strong>Projects in Snyk</strong>
-        </div>
-        <div class=\\"u-padding--sm\\">
-          <a class=\\"u-padding-top--sm\\" href=\\"https://snyk.io/org/org/project/XXX\\">snyk-fixtures/tiny-monorepo:gradle/build.gradle</a><br>
-        </div>
-      </div>
       <div class=\\"border-left overflow-auto\\">
         <div class=\\"border-bottom u-padding--sm\\">
           <strong>License Text</strong>
         </div>
-        <div class=\\"u-padding--sm\\"></div>
+        <div class=\\"u-padding--sm license-text\\"></div>
       </div>
     </div>
     </div>
@@ -404,7 +387,6 @@ THIS SOFTWARE IS PROVIDED BY <<var;name=\\"copyrightHolderAsIs\\";original=\\"TH
       <h1>
         <a href=\\"https://spdx.org/licenses/Unlicense.html\\">Unlicense</a>
       </h1>
-      <strong>Severities</strong>:
     </div>
 
     <div class=\\"display-flex border-right border-top border-bottom border-left u-margin-top--sm\\">
@@ -431,19 +413,11 @@ THIS SOFTWARE IS PROVIDED BY <<var;name=\\"copyrightHolderAsIs\\";original=\\"TH
           </div>
         </div>
       </div>
-      <div class=\\"column border-left\\">
-        <div class=\\"border-bottom u-padding--sm\\">
-          <strong>Projects in Snyk</strong>
-        </div>
-        <div class=\\"u-padding--sm\\">
-          <a class=\\"u-padding-top--sm\\" href=\\"https://snyk.io/org/org/project/XXX\\">snyk-fixtures/npm-with-single-dep:package.json</a><br>
-        </div>
-      </div>
       <div class=\\"border-left overflow-auto\\">
         <div class=\\"border-bottom u-padding--sm\\">
           <strong>License Text</strong>
         </div>
-        <div class=\\"u-padding--sm\\">
+        <div class=\\"u-padding--sm license-text\\">
 
   
     

--- a/test/lib/generate-html-report.test.ts
+++ b/test/lib/generate-html-report.test.ts
@@ -80,5 +80,31 @@ describe('Generate HTML report', () => {
     );
     expect(htmlData).toMatchSnapshot();
   }, 80000);
+  test('License HTML Report is generated as expected with excludeSnykFields enabled', async () => {
+    const licenseRes = (loadJson(
+      __dirname + '/fixtures/example-license-data.json',
+    ) as unknown) as LicenseReportData;
+    const orgData = {
+      name: 'org',
+      id: 'avd-scv',
+      slug: 'org',
+      url: 'https://snyk.io/org/org',
+      group: {
+        name: 'group',
+        id: 'group-1',
+      },
+    };
+    const htmlData = await generateHtmlReport(
+      ORG_ID,
+      licenseRes,
+      orgData,
+      undefined,
+      undefined,
+      {
+        excludeSnykFields: true,
+      }
+    );
+    expect(htmlData).toMatchSnapshot();
+  }, 80000);
   test.todo('Test for when API fails aka bad org id provided');
 });

--- a/test/system/__snapshots__/generate.test.ts.snap
+++ b/test/system/__snapshots__/generate.test.ts.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`\`snyk-licenses-report generate <...>\` Shows error when --excludeSnykFields is used with project-dependencies view 1`] = `"--excludeSnykFields is not supported with with project-dependencies view as Snyk project information is required"`;
+
 exports[`\`snyk-licenses-report generate <...>\` Shows error when invalid --orgPublicId 1`] = `
 "No organization data found for provided ID: my-org.
 Please check that the --orgPublicId is the correct public ID found in Organization Settings page on https://app.snyk.io/org/<ORG_NAME>/manage/settings"
@@ -12,17 +14,20 @@ index.js generate
 Generate org licenses & dependencies report in HTML format
 
 Options:
-  --version       Show version number                                  [boolean]
-  --help          Show help                                            [boolean]
-  --orgPublicId   Public id of the organization in Snyk (available on
-                  organization settings)                              [required]
-  --template      Path to custom Handelbars.js template file (*.hbs)
-  --outputFormat  Report format              [choices: \\"html\\"] [default: \\"html\\"]
-  --view          How should the data be represented. Defaults to a license
-                  based view.
+  --version            Show version number                             [boolean]
+  --help               Show help                                       [boolean]
+  --orgPublicId        Public id of the organization in Snyk (available on
+                       organization settings)                         [required]
+  --template           Path to custom Handelbars.js template file (*.hbs)
+  --outputFormat       Report format         [choices: \\"html\\"] [default: \\"html\\"]
+  --excludeSnykFields  Choose to exclude Snyk information. Excluded information:
+                       organization name, organization links, license severities
+                       in Snyk, license instructions, Snyk project information.
+  --view               How should the data be represented. Defaults to a license
+                       based view.
      [choices: \\"org-licenses\\", \\"project-dependencies\\"] [default: \\"org-licenses\\"]
-  --project       Project ID to filter the results by. E.g. --project=uuid
-                  --project=uuid2                                  [default: []]
+  --project            Project ID to filter the results by. E.g. --project=uuid
+                       --project=uuid2                             [default: []]
 
 Missing required argument: orgPublicId"
 `;

--- a/test/system/generate.test.ts
+++ b/test/system/generate.test.ts
@@ -40,9 +40,44 @@ describe('`snyk-licenses-report generate <...>`', () => {
     );
   });
 
+  it('Shows error when --excludeSnykFields is used with project-dependencies view', async (done) => {
+    exec(
+      `node ${main} generate  --orgPublicId=${ORG_ID} --excludeSnykFields --view=project-dependencies`,
+      {
+        env: {
+          PATH: process.env.PATH,
+          SNYK_TOKEN: process.env.SNYK_TEST_TOKEN,
+        },
+      },
+      (err, stdout, stderr) => {
+        expect(stdout).toBe('');
+        expect(err).toBeNull();
+        expect(stderr.trim()).toMatchSnapshot();
+        done();
+      },
+    );
+  });
+
   it('generated the report successfully with default params', (done) => {
     exec(
       `node ${main} generate --orgPublicId=${ORG_ID}`,
+      {
+        env: {
+          PATH: process.env.PATH,
+          SNYK_TOKEN: process.env.SNYK_TEST_TOKEN,
+        },
+      },
+      (err, stdout) => {
+        expect(err).toBeNull();
+        expect(stdout).toMatch('HTML license report saved at');
+        done();
+      },
+    );
+  }, 80000);
+
+  it('generated the report successfully with project-dependencies view', (done) => {
+    exec(
+      `node ${main} generate --orgPublicId=${ORG_ID} --view=project-dependencies`,
       {
         env: {
           PATH: process.env.PATH,


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Allow to exclude Snyk specific fields from the license based view by passing `--excludeSnykFields`

