### PR TITLE
feat: improve license text format to remove spaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "yargs": "16.0.3"
   },
   "devDependencies": {
+    "@types/cheerio": "0.22.23",
     "@types/jest": "26.0.13",
     "@types/lodash": "4.14.161",
     "@types/node": "14.6.3",

--- a/src/lib/license-text/non-spdx.ts
+++ b/src/lib/license-text/non-spdx.ts
@@ -14,7 +14,7 @@ export async function fetchNonSpdxLicenseTextAndUrl(
       'utf-8',
     );
     const licenseUrl = nonSpdxLicenseUrls[licenseId];
-    return { licenseText, licenseUrl };
+    return { licenseText: `LICENSE TEXT\n${licenseText}`, licenseUrl };
   } catch (e) {
     debug(`Did not fetch license text successfully. Error: ${e}`);
     throw e;

--- a/src/lib/license-text/spdx.ts
+++ b/src/lib/license-text/spdx.ts
@@ -19,8 +19,20 @@ export async function fetchSpdxLicenseTextAndUrl(
       throw new Error(rawHtml);
     }
     const $ = cheerio.load(rawHtml);
-    const licenseText = $('body').text();
-    return { licenseText, licenseUrl };
+    const licenseText = $('[property="spdx:licenseText"]')
+      .text()
+      .replace(/\n\s*\n/g, '\n');
+    const licenseTextHeader = $('[property="spdx:standardLicenseHeader"]')
+      .text()
+      .replace(/\n\s*\n/g, '\n');
+    return {
+      licenseText: `LICENSE TEXT\n${licenseText}${
+        licenseTextHeader
+          ? `\nSTANDARD LICENSE HEADER\n ${licenseTextHeader}`
+          : undefined
+      }`,
+      licenseUrl,
+    };
   } catch (e) {
     debug(`Did not fetch license text successfully. Error: ${e}`);
     throw e;

--- a/test/lib/__snapshots__/fetch-non-spdx-license-text.test.ts.snap
+++ b/test/lib/__snapshots__/fetch-non-spdx-license-text.test.ts.snap
@@ -2,7 +2,8 @@
 
 exports[`ASPSecurityKit-Khosla-Tech license fetched locally as expected 1`] = `
 Object {
-  "licenseText": "<h1>KHOSLA TECH - END USER AGREEMENT</h1>
+  "licenseText": "LICENSE TEXT
+<h1>KHOSLA TECH - END USER AGREEMENT</h1>
 <p><strong>IMPORTANT – PLEASE READ THIS AGREEMENT!</strong></p>
 <div>
     <ul>

--- a/test/lib/__snapshots__/fetch-spdx-license.test.ts.snap
+++ b/test/lib/__snapshots__/fetch-spdx-license.test.ts.snap
@@ -2,114 +2,29 @@
 
 exports[`AFL-1.1 license is as expected 1`] = `
 Object {
-  "licenseText": "
+  "licenseText": "LICENSE TEXT
 
-  
-    
-      
-        Linux Foundation Collaborative Projects
-      
-    
-  
-
-  
-    
-      
-        
-      
-
-      
-        
-          Software Package Data Exchange (SPDX)
-        
-      
-
-    
-   
-
-  
-      
-      
-  
-
-    
-
-      Home » Licenses
-
-      Academic Free License v1.1
-      false
-      Full name
-          Academic Free License v1.1
-
-      Short identifier
-          AFL-1.1
-
-      Other web pages for this license
-          
-            
-             
-               http://opensource.linux-mirror.org/licenses/afl-1.1.txt
-               
-             
-             
-               http://wayback.archive.org/web/20021004124254/http://www.opensource.org/licenses/academic.php [no longer live]
-             
-           
-          
-
-      true
-
-      Notes
-          This license has been superseded by later versions.
-
-      Text
-
-      
-      
-      
          Academic Free License
-
          Version 1.1
-
-      
-      
          The Academic Free License applies to any original work of authorship (the \\"Original Work\\") whose owner
          (the \\"Licensor\\") has placed the following notice immediately following the copyright notice for the
          Original Work:
-
-         
          \\"Licensed under the Academic Free License version 1.1.\\"
-
-         
-      
-
       Grant of License. Licensor hereby grants to any person obtaining a copy of the Original Work (\\"You\\") a
          world-wide, royalty-free, non-exclusive, perpetual, non-sublicenseable license
-
-      
-
-
-            
 (1)
           to use, copy, modify, merge, publish, perform, distribute and/or sell copies of the Original Work
              and derivative works thereof, and
-        
-
-            
 (2)
           under patent claims owned or controlled by the Licensor that are embodied in the Original Work as
              furnished by the Licensor, to make, use, sell and offer for sale the Original Work and
              derivative works thereof, subject to the following conditions.
-        
-
       Right of Attribution. Redistributions of the Original Work must reproduce all copyright notices in the
          Original Work as furnished by the Licensor, both in the Original Work itself and in any documentation
          and/or other materials provided with the distribution of the Original Work in executable form.
-
       Exclusions from License Grant. Neither the names of Licensor, nor the names of any contributors to the
          Original Work, nor any of their trademarks or service marks, may be used to endorse or promote
          products derived from this Original Work without express prior written permission of the Licensor.
-
       WARRANTY AND DISCLAIMERS. LICENSOR WARRANTS THAT THE COPYRIGHT IN AND TO THE ORIGINAL WORK IS OWNED BY
          THE LICENSOR OR THAT THE ORIGINAL WORK IS DISTRIBUTED BY LICENSOR UNDER A VALID CURRENT LICENSE FROM
          THE COPYRIGHT OWNER. EXCEPT AS EXPRESSLY STATED IN THE IMMEDIATELY PRECEEDING SENTENCE, THE ORIGINAL
@@ -118,7 +33,6 @@ Object {
          IS MERCHANTABLE OR FIT FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY OF THE ORIGINAL
          WORK IS WITH YOU. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO
          LICENSE TO ORIGINAL WORK IS GRANTED HEREUNDER EXCEPT UNDER THIS DISCLAIMER.
-
       LIMITATION OF LIABILITY. UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT (INCLUDING
          NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL THE LICENSOR BE LIABLE TO ANY PERSON FOR ANY DIRECT,
          INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER ARISING AS A RESULT OF THIS
@@ -129,7 +43,6 @@ Object {
          NEGLIGENCE TO THE EXTENT APPLICABLE LAW PROHIBITS SUCH LIMITATION. SOME JURISDICTIONS DO NOT ALLOW THE
          EXCLUSION OR LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THIS EXCLUSION AND LIMITATION MAY
          NOT APPLY TO YOU.
-
       License to Source Code. The term \\"Source Code\\" means the preferred form of the Original Work for making
          modifications to it and all available documentation describing how to access and modify the Original
          Work. Licensor hereby agrees to provide a machine-readable copy of the Source Code of the Original
@@ -139,80 +52,19 @@ Object {
          Licensor continues to distribute the Original Work, and by publishing the address of that information
          repository in a notice immediately following the copyright notice that applies to the Original
          Work.
-
       Mutual Termination for Patent Action. This License shall terminate automatically and You may no longer
          exercise any of the rights granted to You by this License if You file a lawsuit in any court alleging
          that any OSI Certified open source software that is licensed under any license containing this \\"Mutual
          Termination for Patent Action\\" clause infringes any patent claims that are essential to use that
          software.
-
       This license is Copyright (C) 2002 Lawrence E. Rosen. All rights reserved.
-
         Permission is hereby granted to copy and distribute this license without modification. This license
              may not be modified without the express written permission of its copyright owner.
-
-    
       
-
-      Standard License Header
-      
-        
-        
+STANDARD LICENSE HEADER
+ 
          \\"Licensed under the Academic Free License version 1.1.\\"
-
-         
-      
-      
-      <<beginOptional>> Academic Free License
-
-Version 1.1<<endOptional>><<beginOptional>> The Academic Free License applies to any original work of authorship (the \\"Original Work\\") whose owner (the \\"Licensor\\") has placed the following notice immediately following the copyright notice for the Original Work:
-
-<<beginOptional>>\\"<<endOptional>>Licensed under the Academic Free License version 1.1.<<beginOptional>>\\"<<endOptional>><<endOptional>>
-
-Grant of License. Licensor hereby grants to any person obtaining a copy of the Original Work (\\"You\\") a world-wide, royalty-free, non-exclusive, perpetual, non-sublicenseable license
-
-   <<var;name=\\"bullet\\";original=\\"(1)\\";match=\\".{0,20}\\">> to use, copy, modify, merge, publish, perform, distribute and/or sell copies of the Original Work and derivative works thereof, and
-
-   <<var;name=\\"bullet\\";original=\\"(2)\\";match=\\".{0,20}\\">> under patent claims owned or controlled by the Licensor that are embodied in the Original Work as furnished by the Licensor, to make, use, sell and offer for sale the Original Work and derivative works thereof, subject to the following conditions.
-
-Right of Attribution. Redistributions of the Original Work must reproduce all copyright notices in the Original Work as furnished by the Licensor, both in the Original Work itself and in any documentation and/or other materials provided with the distribution of the Original Work in executable form.
-
-Exclusions from License Grant. Neither the names of Licensor, nor the names of any contributors to the Original Work, nor any of their trademarks or service marks, may be used to endorse or promote products derived from this Original Work without express prior written permission of the Licensor.
-
-WARRANTY AND DISCLAIMERS. LICENSOR WARRANTS THAT THE COPYRIGHT IN AND TO THE ORIGINAL WORK IS OWNED BY THE LICENSOR OR THAT THE ORIGINAL WORK IS DISTRIBUTED BY LICENSOR UNDER A VALID CURRENT LICENSE FROM THE COPYRIGHT OWNER. EXCEPT AS EXPRESSLY STATED IN THE IMMEDIATELY PRECEEDING SENTENCE, THE ORIGINAL WORK IS PROVIDED UNDER THIS LICENSE ON AN \\"AS IS\\" BASIS, WITHOUT WARRANTY, EITHER EXPRESS OR IMPLIED, INCLUDING, WITHOUT LIMITATION, THE WARRANTY OF NON-INFRINGEMENT AND WARRANTIES THAT THE ORIGINAL WORK IS MERCHANTABLE OR FIT FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY OF THE ORIGINAL WORK IS WITH YOU. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN ESSENTIAL PART OF THIS LICENSE. NO LICENSE TO ORIGINAL WORK IS GRANTED HEREUNDER EXCEPT UNDER THIS DISCLAIMER.
-
-LIMITATION OF LIABILITY. UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY, WHETHER TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL THE LICENSOR BE LIABLE TO ANY PERSON FOR ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER ARISING AS A RESULT OF THIS LICENSE OR THE USE OF THE ORIGINAL WORK INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF GOODWILL, WORK STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER COMMERCIAL DAMAGES OR LOSSES, EVEN IF SUCH PERSON SHALL HAVE BEEN INFORMED OF THE POSSIBILITY OF SUCH DAMAGES. THIS LIMITATION OF LIABILITY SHALL NOT APPLY TO LIABILITY FOR DEATH OR PERSONAL INJURY RESULTING FROM SUCH PARTY'S NEGLIGENCE TO THE EXTENT APPLICABLE LAW PROHIBITS SUCH LIMITATION. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO THIS EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU.
-
-License to Source Code. The term \\"Source Code\\" means the preferred form of the Original Work for making modifications to it and all available documentation describing how to access and modify the Original Work. Licensor hereby agrees to provide a machine-readable copy of the Source Code of the Original Work along with each copy of the Original Work that Licensor distributes. Licensor reserves the right to satisfy this obligation by placing a machine-readable copy of the Source Code in an information repository reasonably calculated to permit inexpensive and convenient access by You for as long as Licensor continues to distribute the Original Work, and by publishing the address of that information repository in a notice immediately following the copyright notice that applies to the Original Work.
-
-Mutual Termination for Patent Action. This License shall terminate automatically and You may no longer exercise any of the rights granted to You by this License if You file a lawsuit in any court alleging that any OSI Certified open source software that is licensed under any license containing this \\"Mutual Termination for Patent Action\\" clause infringes any patent claims that are essential to use that software.
-
-This license is Copyright (C) 2002 Lawrence E. Rosen. All rights reserved.
-
-Permission is hereby granted to copy and distribute this license without modification. This license may not be modified without the express written permission of its copyright owner.
-      
-
-     
-
-    
-      
-        
-          
-            © 2018          SPDX Workgroup a Linux Foundation Project. All Rights Reserved.        
-            Linux Foundation is a registered trademark of The Linux Foundation. Linux is a registered trademark of Linus Torvalds.
-            Please see our privacy policy and terms of use.
-          
-        
-      
-    
-
-    
-      top of page
-    
-
-  
-
-",
+      ",
   "licenseUrl": "https://spdx.org/licenses/AFL-1.1.html",
 }
 `;


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
- Reduce the previously seen large whitespace leftover from converting HTML to text.
- Specifically target only certain SPDX page section like License Text and the License Header (more can be added as needed), this concentrates the license text to only the main text and useful information.

## Before
<img width="1429" alt="CleanShot 2021-01-19 at 11 55 23@2x" src="https://user-images.githubusercontent.com/2911613/105035621-343b0280-5a53-11eb-9fb1-32137049e41f.png">

## After
<img width="1440" alt="CleanShot 2021-01-19 at 12 37 35@2x" src="https://user-images.githubusercontent.com/2911613/105035595-284f4080-5a53-11eb-947e-79c472161fb7.png">
