### PR TITLE
feat: use Node 14 for release step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ commands:
 jobs:
     build-test-monitor:
         docker:
-            - image: circleci/node:12
+            - image: circleci/node:14
         steps:
             - slack/notify:
                 channel: C0137E8F72A


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Use Node 14 for release step as latest `semantic-release` requires it