### PR TITLE
fix: support Dual licenses since API changed

### DIFF
--- a/src/lib/generate-report/templates/licenses-view.hbs
+++ b/src/lib/generate-report/templates/licenses-view.hbs
@@ -91,7 +91,7 @@
     }
 
     .column-large {
-      flex: 1 0 320px;
+      flex: 1 0 50%;
       max-width: 100%;
     }
 

--- a/test/lib/__snapshots__/generate-html-report.test.ts.snap
+++ b/test/lib/__snapshots__/generate-html-report.test.ts.snap
@@ -94,7 +94,7 @@ exports[`Generate HTML report License HTML Report is generated as expected 1`] =
     }
 
     .column-large {
-      flex: 1 0 320px;
+      flex: 1 0 50%;
       max-width: 100%;
     }
 
@@ -840,7 +840,7 @@ exports[`Generate HTML report License HTML Report is generated as expected with 
     }
 
     .column-large {
-      flex: 1 0 320px;
+      flex: 1 0 50%;
       max-width: 100%;
     }
 

--- a/test/lib/unit.test.ts
+++ b/test/lib/unit.test.ts
@@ -179,4 +179,97 @@ describe('mergeLicenceAndDepData', () => {
         .copyright,
     ).toEqual(depApiData['abbrev@1.0.9'][0].copyright);
   });
+  test('mergeLicenceAndDepData for a multi license returns extra licenses after separating multi licenses', async () => {
+    const licenseData = ({
+      results: [
+        {
+          id: 'ISC OR MIT',
+          severity: '',
+          instructions: '',
+          dependencies: [
+            {
+              id: 'atob@2.1.1',
+              name: 'atob',
+              version: '2.1.1',
+              packageManager: 'npm',
+            },
+            {
+              id: 'optimist@0.6.1',
+              name: 'optimist',
+              version: '0.6.1',
+              packageManager: 'npm',
+            },
+            {
+              id: 'abbrev@1.0.9',
+              name: 'abbrev',
+              version: '1.0.9',
+              packageManager: 'npm',
+            },
+            {
+              id: 'wordwrap@0.0.2',
+              name: 'wordwrap',
+              version: '0.0.2',
+              packageManager: 'npm',
+            },
+          ],
+          projects: [
+            {
+              id: 'abc',
+              name: 'snyk-fixtures/mono-repo:package.json',
+            },
+          ],
+        },
+      ],
+    } as unknown) as snykApiSdk.OrgTypes.LicensesPostResponseType;
+
+    const depApiData = {
+      'abbrev@1.0.9': [
+        {
+          id: 'abbrev@1.0.9',
+          name: 'abbrev',
+          version: '1.0.9',
+          type: 'npm',
+          issuesCritical: 0,
+          issuesHigh: 0,
+          issuesMedium: 0,
+          issuesLow: 0,
+          dependenciesWithIssues: [],
+          licenses: [
+            {
+              id: 'snyk:lic:npm:abbrev:ISC',
+              title: 'ISC OR MIT license',
+              license: 'ISC OR MIT',
+            },
+          ],
+          projects: [
+            {
+              id: 'abc',
+              name: 'snyk-fixtures/mono-repo:package.json',
+            },
+          ],
+          latestVersion: '1.1.1',
+          latestVersionPublishedDate: '2017-09-28T02:47:13.220Z',
+          firstPublishedDate: '2011-03-21T22:21:11.183Z',
+          isDeprecated: false,
+          copyright: ['Copyright (c) Isaac Z. Schlueter and Contributors'],
+        },
+      ],
+    };
+    const res = await mergeLicenceAndDepData(licenseData, depApiData);
+    expect(Object.values(res)).toHaveLength(2);
+    expect(res['ISC'].dependencies.length).toEqual(
+      licenseData.results[0].dependencies.length,
+    );
+    expect(res['MIT'].dependencies.length).toEqual(
+      licenseData.results[0].dependencies.length,
+    );
+    expect(
+      res['ISC'].dependencies.filter((dep) => dep.id === 'abbrev@1.0.9')[0]
+        .copyright,
+    ).toEqual(depApiData['abbrev@1.0.9'][0].copyright);
+    expect(
+      res['MIT'].dependencies.filter((dep) => dep.id === 'abbrev@1.0.9')[0]
+        .copyright,
+    ).toEqual(depApiData['abbrev@1.0.9'][0].copyright);
+  });
 });


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

Since this change the multi licenses no longer come separated
https://updates.snyk.io/bug-fix-dependencies-using-dual-multiple-licenses-alignment-186782
we have to separate them ourselves
