### PR TITLE
test: update license text that has a new space

### DIFF
--- a/test/lib/__snapshots__/fetch-spdx-license.test.ts.snap
+++ b/test/lib/__snapshots__/fetch-spdx-license.test.ts.snap
@@ -12,10 +12,10 @@ Object {
          \\"Licensed under the Academic Free License version 1.1.\\"
       Grant of License. Licensor hereby grants to any person obtaining a copy of the Original Work (\\"You\\") a
          world-wide, royalty-free, non-exclusive, perpetual, non-sublicenseable license
-            (1)
+             (1)
           to use, copy, modify, merge, publish, perform, distribute and/or sell copies of the Original Work
              and derivative works thereof, and
-            (2)
+             (2)
           under patent claims owned or controlled by the Licensor that are embodied in the Original Work as
              furnished by the Licensor, to make, use, sell and offer for sale the Original Work and
              derivative works thereof, subject to the following conditions.


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
One of the licenses texts space has been added/removed which broke the snapshot assertion. Updating the test