### PR TITLE
chore: upgrade snyk orb to snyk/snyk@1.1.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    snyk: snyk/snyk@0.0.8
+    snyk: snyk/snyk@1.1.2
     puppeteer: threetreeslight/puppeteer@0.1.2
     slack: circleci/slack@3.4.2
 commands:


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Upgrade snyk orb to latest as the snyk repo was renamed which breaks the older orbs