### PR TITLE
feat: call licenses & deps API in parallel

### DIFF
--- a/src/lib/api/org/dependencies.ts
+++ b/src/lib/api/org/dependencies.ts
@@ -41,9 +41,10 @@ async function getAllDependenciesData(
     results: [],
     total: undefined,
   };
-  const perPage = 20; // this is a max on that endpoint
+  const perPage = 20; // 1000 is a max on that endpoint, however anything other than 20 is not working
 
   let currentPage = page;
+
   let hasMorePages = true;
 
   while (hasMorePages) {

--- a/src/lib/api/org/licenses.ts
+++ b/src/lib/api/org/licenses.ts
@@ -4,7 +4,6 @@ import * as snykApiSdk from 'snyk-api-ts-client';
 import { getApiToken } from '../../get-api-token';
 import { requestsManager } from 'snyk-request-manager';
 import { GetLicenseDataOptions } from '../../types';
-import { number } from 'yargs';
 
 const debug = debugLib('snyk-licenses:getLicenseDataForOrg');
 

--- a/src/lib/generate-org-license-report.ts
+++ b/src/lib/generate-org-license-report.ts
@@ -33,7 +33,10 @@ export async function generateLicenseData(
   debug(`ℹ️  Generating license data for Org:${orgPublicId}`);
 
   try {
-    const licenseData = await getLicenseDataForOrg(orgPublicId, options);
+    const [licenseData, dependenciesDataRaw] = await Promise.all([
+      getLicenseDataForOrg(orgPublicId, options),
+      getDependenciesDataForOrg(orgPublicId, options),
+    ]);
     if (!licenseData.total) {
       debug(`ℹ️  Detected 0 licenses`);
       throw new Error(
@@ -41,10 +44,6 @@ export async function generateLicenseData(
       );
     }
     debug(`✅ Got license API data for Org:${orgPublicId}`);
-    const dependenciesDataRaw = await getDependenciesDataForOrg(
-      orgPublicId,
-      options,
-    );
     if (!dependenciesDataRaw.total || dependenciesDataRaw.total === 0) {
       debug(`ℹ️  API returned 0 dependencies`);
     } else {


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does
Bump per page for /dependencies API to it's max