### PR TITLE
fix: include html templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build-watch": "tsc -w && npm run copy:templates",
     "prepare": "npm run build",
     "snyk-test": "snyk test",
-    "copy:templates": "cpx 'src/**/*.hbs' ./dist"
+    "copy:templates": "cpx 'src/**/*.{hbs,html}' ./dist"
   },
   "bin": {
     "snyk-licenses-report": "dist/index.js"


### PR DESCRIPTION
include license text htmls in dist folder at release package

### What this does

This PR will copy html templates to dist folder at release packaging.

### Notes for the reviewer

Run command with `generate` option to generate a license html with EDL-1.0 license which will embed text from `EDL-1.0.html` inside dist folder.

### Screenshots
<img width="1588" alt="Screenshot 2023-02-10 at 6 42 01 PM" src="https://user-images.githubusercontent.com/108258271/218072206-562bf4e8-2316-4b2a-94d3-c62068869833.png">

