### PR TITLE
fix: include html templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build-watch": "tsc -w && npm run copy:templates",
     "prepare": "npm run build",
     "snyk-test": "snyk test",
-    "copy:templates": "cpx 'src/**/*.hbs' ./dist"
+    "copy:templates": "cpx 'src/**/*.{hbs,html}' ./dist"
   },
   "bin": {
     "snyk-licenses-report": "dist/index.js"


### PR DESCRIPTION
include license text htmls in dist folder at release package

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

This PR will copy html templates to dist folder at release packaging.

### Notes for the reviewer

Run command with generate option to generate a license html with EDL-1.0 license which will embed text from EDL-1.0.html inside dist folder.

### More information

Certain non-SPDX licenses uses embedded html licenses texts which are to be packaged in the binary release

### Screenshots

<img width="1588" alt="EDL-1 0-screen-capture" src="https://user-images.githubusercontent.com/108258271/222107839-afb6bad3-d6b6-49f7-b1c9-3fd79f9a69b6.png">

