### PR TITLE
Fix/semantic release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,6 @@ jobs:
                 color: '#42e2f4'
                 message: Starting snyk-licenses build & monitor
             - checkout
-            - run: npm install semantic-release @semantic-release/exec pkg --save-dev
             - install_deps
             - build_ts
             - run: npm test

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "cpx": "1.5.0",
     "eslint": "8.18.0",
     "jest": "26.4.2",
+    "pkg": "5.8.0",
     "prettier": "2.7.1",
     "semantic-release": "17.3.0",
     "ts-jest": "25.5.1",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "yargs": "17.6.0"
   },
   "devDependencies": {
+    "@semantic-release/exec": "5.0.0",
     "@types/cheerio": "0.22.31",
     "@types/jest": "29.1.2",
     "@types/lodash": "4.14.186",
@@ -62,6 +63,7 @@
     "eslint": "8.18.0",
     "jest": "26.4.2",
     "prettier": "2.7.1",
+    "semantic-release": "17.3.0",
     "ts-jest": "25.5.1",
     "ts-node": "8.6.2",
     "tsc-watch": "^4.1.0",


### PR DESCRIPTION
pin semantic-release to work on node14

- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [ ] Documentation written in Wiki/[README](../README.md)
- [ ] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

This PR pins a semantic-release version to work on a node14 build

### Notes for the reviewer

For npx to make call to pinned semantic-release version and build its release package binaries

### More information

- [[Link to documentation](https://github.com/semantic-release/semantic-release/blob/master/docs/support/node-version.md)] latest version of semantic-release only work on >= node18
