### PR TITLE
docs: update for copyright service end-of-life

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 [![Inactively Maintained](https://img.shields.io/badge/Maintenance%20Level-Inactively%20Maintained-yellowgreen.svg)](https://gist.github.com/cheerfulstoic/d107229326a01ff0f333a1d3476e068d)
 
 
-**This repository is in maintenance mode, no new features are being developed. Bug & security fixes will continue to be delivered. Open source contributions are welcome for small features & fixes (no breaking changes)**
+:warning: **This repository is in maintenance mode, no new features are being developed. Bug & security fixes will continue to be delivered. Open source contributions are welcome for small features & fixes (no breaking changes)**
+
+:warning: **Please note that as of January 8, 2024 copyright data will no longer be available due to [Copyright Service End-of-Life](https://updates.snyk.io/snyk-open-source-upcoming-end-of-life-notice-for-copyright-service-effective-january-8-2024-280362)**
 
 Snyk helps you find, fix and monitor for known vulnerabilities in your dependencies, both on an ad hoc basis and as part of your CI (Build) system.
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk-tech-services/general/wiki/Tests)
- [x] Documentation written in Wiki/[README](../README.md)
- [x] Commit history is tidy & follows Contributing guidelines [ℹ︎](./CONTRIBUTING.md#commit-messages)


### What this does

make users aware that copyright data will no longer be provided due to upcoming copyright service end-of-life

