### PR TITLE
fix: update SPDX id GPL-2.0 to GPL-2.0-only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,21 +3,6 @@ orbs:
     puppeteer: threetreeslight/puppeteer@0.1.2
     slack: circleci/slack@3.4.2
 commands:
-  install_deps:
-    description: Install dependencies
-    steps:
-      - run:
-            name: Install dependencies
-            command: npm install
-      - run:
-            name: Install Headless Chrome dependencies
-            command: |
-                sudo apt update && sudo apt-get install -yq \
-                gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 \
-                libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 \
-                libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 \
-                libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
-                fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget
   build_ts:
     description: Build js files from ts
     steps:
@@ -31,30 +16,36 @@ commands:
 jobs:
     build-test-monitor:
         docker:
-            - image: circleci/node:14
+            - image: cimg/node:14.17-browsers
         steps:
             - slack/notify:
                 channel: C0137E8F72A
                 color: '#42e2f4'
                 message: Starting snyk-licenses build & monitor
             - checkout
-            - install_deps
+            - run:
+                name: Install Dependencies
+                command: npm install
             - build_ts
-            - run: npm test
+            - run:
+                name: Run Tests
+                command: npm test
             - run: npx semantic-release
             - slack/status:
                 fail_only: true
                 only_for_branches: master
     build-test:
         docker:
-            - image: circleci/node:14
+            - image: cimg/node:14.17-browsers
         steps:
             - slack/notify:
                 channel: C0137E8F72A
                 color: '#42e2f4'
                 message: Starting snyk-licenses test
             - checkout
-            - install_deps
+            - run:
+                name: Install Dependencies
+                command: npm install
             - build_ts
             - run: npm test
             - slack/status:
@@ -62,10 +53,12 @@ jobs:
                 only_for_branches: master
     build-test-from-fork:
         docker:
-            - image: circleci/node:14
+            - image: cimg/node:14.17-browsers
         steps:
             - checkout
-            - install_deps
+            - run:
+                name: Install Dependencies
+                command: npm install
             - run: npm test
 workflows:
     version: 2

--- a/src/lib/license-text/spdx.ts
+++ b/src/lib/license-text/spdx.ts
@@ -10,6 +10,11 @@ export async function fetchSpdxLicenseTextAndUrl(
     // The SPDX name for Public Domain license is Unlicense.
     licenseId = 'Unlicense';
   }
+  if(licenseId === 'GPL-2.0') {
+    // The SPDX id for GPL-2.0 is deprecated, change it to GPL-2.0-only
+    licenseId = 'GPL-2.0-only';
+  }
+
   const debug = debugLib('snyk-licenses:fetchSpdxLicenseText');
   const licenseUrl = `https://spdx.org/licenses/${licenseId}.html`;
   try {


### PR DESCRIPTION
The SPDX ID 'GPL-2.0' is deprecated. This change
updates it to the current equivalent,
'GPL-2.0-only', to ensure compliance with SPDX
standards.

See https://spdx.org/licenses/GPL-2.0.html
